### PR TITLE
feat: add runWithoutDerivative

### DIFF
--- a/Sources/Differentiation/RunWithoutDerivative.swift
+++ b/Sources/Differentiation/RunWithoutDerivative.swift
@@ -1,0 +1,6 @@
+@inlinable
+@_alwaysEmitIntoClient
+@_semantics("autodiff.nonvarying")
+public func runWithoutDerivative<T>(_ body: () -> T) -> T {
+    body()
+}

--- a/Tests/DifferentiationTests/RunWithoutDerivativeTests.swift
+++ b/Tests/DifferentiationTests/RunWithoutDerivativeTests.swift
@@ -1,0 +1,38 @@
+import Differentiation
+import Testing
+
+@Suite
+struct RunWithoutDerivativeTests {
+    @Test
+    func reserveCapacity() {
+        @differentiable(reverse)
+        func f(x: Double) -> [Double] {
+            var array: [Double] = []
+            let capacity = 3
+
+            runWithoutDerivative {
+                array.reserveCapacity(capacity)
+            }
+
+            for _ in 0 ..< capacity {
+                array.append(x)
+            }
+
+            return array
+        }
+
+        #expect(f(x: 5.0) == [5.0, 5.0, 5.0])
+    }
+
+    @Test
+    func ignoreSquaredContribution() {
+        @differentiable(reverse)
+        func f(x: Double) -> Double {
+            x + runWithoutDerivative { x * x }
+        }
+
+        let (value, gradient) = valueWithGradient(at: 2.0, of: f)
+        #expect(value == 6.0)
+        #expect(gradient == 1.0) // instead of the normally expected 5.0
+    }
+}


### PR DESCRIPTION
This enables:
- Calling functions that aren't differentiable (like `array.reserveCapacity(x)`)
- Exclude parts that are differentiable from a derivative. 