### PR TITLE
feat: differentiable zip support

### DIFF
--- a/Sources/Benchmarks/Implementation/zipMapAdd.swift
+++ b/Sources/Benchmarks/Implementation/zipMapAdd.swift
@@ -1,0 +1,106 @@
+import CollectionsBenchmark
+import Differentiation
+import Foundation
+
+private let benchmarkTitle = "zipMapAddNew"
+
+extension Array where Element == Float {
+    static func addZipMapAddBenchmarks(_ benchmark: inout Benchmark) {
+        benchmark.add(
+            title: benchmarkTitle,
+            type: Self.self,
+            regular: { lhs, rhs in
+                { _ in
+                    blackHole(zip(lhs, rhs).differentiableMap { $0 + $1 })
+                }
+            },
+            forward: { lhs, rhs in
+                { _ in
+                    blackHole(valueWithPullback(at: lhs, rhs, of: { zip($0, $1).differentiableMap { $0 + $1 } }).value)
+                }
+            },
+            reverse: { lhs, rhs in
+                let pullback = valueWithPullback(
+                    at: lhs, rhs, of: { zip($0, $1).differentiableMap { $0 + $1 } }
+                ).pullback
+
+                var basisVector = Array.DifferentiableView([Float](repeating: 0, count: lhs.count))
+                basisVector.base[0] = 1
+                return { _ in
+                    blackHole(pullback(basisVector))
+                }
+            }
+        )
+
+        benchmark.add(
+            title: "\(Array.self).\(benchmarkTitle) - total",
+            input: (Array<Float>, Array<Float>).self
+        ) { lhs, rhs in
+            var tangent = Array<Float>.DifferentiableView(repeating: 0, count: lhs.count)
+            tangent[0] = 1.0
+            return { _ in
+                let pullback = valueWithPullback(
+                    at: lhs, rhs, of: { zip($0, $1).differentiableMap { $0 + $1 } }
+                ).pullback
+
+                let gradient = pullback(tangent)
+
+                blackHole(gradient)
+            }
+        }
+
+        benchmark.add(
+            title: benchmarkTitle + " using for loop",
+            type: Self.self,
+            regular: { lhs, rhs in
+                { _ in
+                    var result: [Float] = []
+                    result.reserveCapacity(lhs.count)
+                    for i in lhs.indices {
+                        result.append(lhs[i] + rhs[i])
+                    }
+                    blackHole(result)
+                }
+            },
+            forward: { lhs, rhs in
+                { _ in
+                    blackHole(
+                        valueWithPullback(
+                            at: lhs, rhs,
+                            of: { lhs, rhs in
+                                var results: [Float] = []
+                                runWithoutDerivative {
+                                    results.reserveCapacity(lhs.count)
+                                }
+                                for i in withoutDerivative(at: lhs.indices) {
+                                    results.append(lhs[i] + rhs[i])
+                                }
+                                return results
+                            }
+                        ).value
+                    )
+                }
+            },
+            reverse: { lhs, rhs in
+                let pullback = valueWithPullback(
+                    at: lhs, rhs, of: { lhs, rhs in
+                        var results: [Float] = []
+                        runWithoutDerivative {
+                            results.reserveCapacity(lhs.count)
+                        }
+                        for i in withoutDerivative(at: lhs.indices) {
+                            results.append(lhs[i] + rhs[i])
+                        }
+                        return results
+                    }
+                ).pullback
+
+                var basisVector = Array.DifferentiableView([Float](repeating: 0, count: lhs.count))
+                basisVector.base[0] = 1
+                return { _ in
+                    blackHole(pullback(basisVector))
+                }
+            }
+        )
+    }
+}

--- a/Sources/Benchmarks/main.swift
+++ b/Sources/Benchmarks/main.swift
@@ -17,6 +17,7 @@ benchmark.registerInputGenerator(for: ([Float], [Float]).self) { size in
 
 protocol HasBenchmarks {
     static func addMapReduceBenchmarks(_ benchmark: inout Benchmark)
+    static func addZipMapAddBenchmarks(_ benchmark: inout Benchmark)
     static func addMeanSquaredErrorBenchmarks(_ benchmark: inout Benchmark)
     static func addLaplaceBenchmarks(_ benchmark: inout Benchmark)
     static func addSubscriptGetContinuousBenchmarks(_ benchmark: inout Benchmark)
@@ -32,6 +33,7 @@ let types: [HasBenchmarks.Type] = [
 
 for type in types {
     type.addMapReduceBenchmarks(&benchmark)
+    type.addZipMapAddBenchmarks(&benchmark)
     type.addMeanSquaredErrorBenchmarks(&benchmark)
     type.addLaplaceBenchmarks(&benchmark)
     type.addSubscriptGetContinuousBenchmarks(&benchmark)

--- a/Sources/Differentiation/Zip+Differentiable.swift
+++ b/Sources/Differentiation/Zip+Differentiable.swift
@@ -1,0 +1,167 @@
+#if canImport(_Differentiation)
+
+import _Differentiation
+
+@derivative(of: zip)
+@inlinable
+public func _vjpZip<Sequence1, Sequence2>(
+    _ sequence1: Sequence1, _ sequence2: Sequence2
+) -> (
+    value: Zip2Sequence<Sequence1, Sequence2>,
+    pullback: (Zip2Sequence<Sequence1, Sequence2>.TangentVector) -> (Sequence1.TangentVector, Sequence2.TangentVector)
+) where
+    Sequence1: Differentiable & RangeReplaceableCollection,
+    Sequence2: Differentiable & RangeReplaceableCollection,
+    Sequence1.Element: Differentiable,
+    Sequence2.Element: Differentiable,
+    Sequence1.TangentVector: RangeReplaceableCollection,
+    Sequence2.TangentVector: RangeReplaceableCollection,
+    Sequence1.TangentVector.Element == Sequence1.Element.TangentVector,
+    Sequence2.TangentVector.Element == Sequence2.Element.TangentVector
+{
+    (
+        value: zip(sequence1, sequence2),
+        pullback: { v in
+            (v.sequence1, v.sequence2)
+        }
+    )
+}
+
+extension Zip2Sequence: @retroactive Differentiable where
+    Sequence1: Differentiable & RangeReplaceableCollection,
+    Sequence2: Differentiable & RangeReplaceableCollection,
+    Sequence1.Element: Differentiable,
+    Sequence2.Element: Differentiable,
+    Sequence1.TangentVector: RangeReplaceableCollection,
+    Sequence2.TangentVector: RangeReplaceableCollection,
+    Sequence1.TangentVector.Element == Sequence1.Element.TangentVector,
+    Sequence2.TangentVector.Element == Sequence2.Element.TangentVector
+{
+    @inlinable
+    public mutating func move(by offset: TangentVector) {
+        // TODO: inside the stdlib we might be able to do this work in place
+        var result1 = Sequence1()
+        var result2 = Sequence2()
+
+        for (original, offset) in zip(self, offset) {
+            var original = original
+
+            original.0.move(by: offset.0)
+            original.1.move(by: offset.1)
+
+            result1.append(original.0)
+            result2.append(original.1)
+        }
+        self = zip(result1, result2)
+    }
+
+    @inlinable
+    public func differentiableMap<Result: Differentiable>(_ transform: @differentiable(reverse) (Sequence1.Element, Sequence2.Element)
+        -> Result
+    ) -> [Result] {
+        self.map(transform)
+    }
+
+    @derivative(of: differentiableMap)
+    @inlinable
+    public func _vjpDifferentiableMap<Result: Differentiable>(_ transform: @differentiable(reverse) (Sequence1.Element, Sequence2.Element)
+        -> Result
+    ) -> (value: [Result], pullback: ([Result].TangentVector) -> Zip2Sequence.TangentVector) {
+        var results: [Result] = []
+        results.reserveCapacity(self.underestimatedCount)
+        var pullbacks: [(Result.TangentVector) -> (Sequence1.Element.TangentVector, Sequence2.Element.TangentVector)] = []
+        results.reserveCapacity(self.underestimatedCount)
+
+        for pair in self {
+            let (value, pullback) = valueWithPullback(at: pair.0, pair.1, of: transform)
+            results.append(value)
+            pullbacks.append(pullback)
+        }
+
+        return (
+            value: results,
+            pullback: { v in
+                var results1 = Sequence1.TangentVector()
+                results1.reserveCapacity(v.count)
+                var results2 = Sequence2.TangentVector()
+                results2.reserveCapacity(v.count)
+
+                for (tangentElement, pullback) in zip(v, pullbacks) {
+                    let (result1, result2) = pullback(tangentElement)
+                    results1.append(result1)
+                    results2.append(result2)
+                }
+
+                return TangentVector(results1, results2)
+            }
+        )
+    }
+}
+
+extension Zip2Sequence {
+    public struct TangentVector: Sequence & Differentiable & AdditiveArithmetic where Sequence1: Differentiable, Sequence2: Differentiable,
+        Sequence1.TangentVector: Sequence, Sequence2.TangentVector: Sequence
+    {
+        public typealias TangentVector = Self
+        public typealias Element = (Sequence1.TangentVector.Element, Sequence2.TangentVector.Element)
+
+        @usableFromInline
+        var sequence1: Sequence1.TangentVector
+        @usableFromInline
+        var sequence2: Sequence2.TangentVector
+
+        @inlinable
+        init(_ sequence1: Sequence1.TangentVector, _ sequence2: Sequence2.TangentVector) {
+            self.sequence1 = sequence1
+            self.sequence2 = sequence2
+        }
+
+        @inlinable
+        public __consuming func makeIterator() -> Iterator {
+            Iterator(baseStream1: sequence1.makeIterator(), baseStream2: sequence2.makeIterator())
+        }
+
+        @inlinable // generic-performance
+        public var underestimatedCount: Int {
+            Swift.min(
+                sequence1.underestimatedCount,
+                sequence2.underestimatedCount
+            )
+        }
+
+        public struct Iterator: IteratorProtocol {
+            public typealias Element = (Sequence1.TangentVector.Element, Sequence2.TangentVector.Element)
+
+            @usableFromInline
+            var baseStream1: Sequence1.TangentVector.Iterator
+            @usableFromInline
+            var baseStream2: Sequence2.TangentVector.Iterator
+            @usableFromInline
+            var reachedEnd: Bool = false
+
+            @inlinable
+            init(baseStream1: Sequence1.TangentVector.Iterator, baseStream2: Sequence2.TangentVector.Iterator) {
+                self.baseStream1 = baseStream1
+                self.baseStream2 = baseStream2
+            }
+
+            @inlinable
+            public mutating func next() -> (Sequence1.TangentVector.Element, Sequence2.TangentVector.Element)? {
+                if reachedEnd {
+                    return nil
+                }
+
+                guard let element1 = baseStream1.next(),
+                      let element2 = baseStream2.next() else
+                {
+                    reachedEnd = true
+                    return nil
+                }
+
+                return (element1, element2)
+            }
+        }
+    }
+}
+
+#endif

--- a/Tests/DifferentiationTests/Zip+DifferentiableTests.swift
+++ b/Tests/DifferentiationTests/Zip+DifferentiableTests.swift
@@ -1,0 +1,73 @@
+import _Differentiation
+@testable import Differentiation
+import Testing
+
+@Suite
+struct ZipDifferentiableTests {
+    @Test
+    func zipCall() {
+        let a: [Double] = [1, 2, 3]
+        let b: [Double] = [5, 6, 7]
+
+        let (value, pullback) = valueWithPullback(at: a, b, of: { s1, s2 in
+            zip(s1, s2)
+        })
+
+        #expect(value.map(\.0) == a)
+        #expect(value.map(\.1) == b)
+
+        let va: [Double].DifferentiableView = [1, 0, 0]
+        let vb: [Double].DifferentiableView = [0, 0, 0]
+
+        let gradient = pullback(Zip2Sequence.TangentVector(va, vb))
+        #expect(gradient == ([1, 0, 0], [0, 0, 0]))
+    }
+
+    @Test
+    func zipMapAdd() {
+        let a: [Double] = [1, 2, 3]
+        let b: [Double] = [5, 6, 7]
+
+        let (value, pullback) = valueWithPullback(at: a, b, of: { s1, s2 in
+            zip(s1, s2).differentiableMap { $0 + $1 }
+        })
+
+        #expect(value == [6, 8, 10])
+
+        let gradient = pullback([1, 0, 0])
+        #expect(gradient == ([1, 0, 0], [1, 0, 0]))
+    }
+
+    @Test
+    func zipMapMultiply() {
+        let a: [Double] = [1, 2, 3]
+        let b: [Double] = [5, 6, 7]
+
+        let (value, pullback) = valueWithPullback(at: a, b, of: { s1, s2 in
+            zip(s1, s2).differentiableMap { $0 * $1 }
+        })
+
+        #expect(value == [5, 12, 21])
+
+        let gradient1 = pullback([1, 0, 0])
+        #expect(gradient1 == ([5, 0, 0], [1, 0, 0]))
+
+        let gradient2 = pullback([0, 1, 0])
+        #expect(gradient2 == ([0, 6, 0], [0, 2, 0]))
+    }
+
+    @Test
+    func zipMapReduce() {
+        let a: [Double] = [1, 2, 3]
+        let b: [Double] = [5, 6, 7]
+
+        let (value, pullback) = valueWithPullback(at: a, b, of: { s1, s2 in
+            zip(s1, s2).differentiableMap { $0 + $1 }.differentiableReduce(0.0) { $0 + $1 }
+        })
+
+        #expect(value == 24.0)
+
+        let gradient = pullback(1.0)
+        #expect(gradient == ([1.0, 1.0, 1.0], [1.0, 1.0, 1.0]))
+    }
+}


### PR DESCRIPTION
This adds differentiable zip support allowing us to make the following expressions differentiable: 
```
@differentiable(reverse)
func zipMapAdd(a: [Double], b: [Double]) -> Double {
    zip(s1, s2).differentiableMap { $0 + $1 }.differentiableReduce(0.0) { $0 + $1 }
}
```

Essentially allowing us to apply functions to pairwise elements of separate collections. 
Previously this could be achieved with arrays and a simple for loop but this unfortunately scales exponentially due to the allocation of "one hot tangent vectors". 
This solution scales linearly with the amount of elements in the collections