### PR TITLE
!feat: change zip underlying implementation

### DIFF
--- a/DifferentiableZipCodeGenerator/Sources/DifferentiableZipCodeGenerator/ZipSequenceGenerator.swift
+++ b/DifferentiableZipCodeGenerator/Sources/DifferentiableZipCodeGenerator/ZipSequenceGenerator.swift
@@ -199,9 +199,10 @@ enum ZipSequenceGenerator {
                 return (
                     value: results,
                     pullback: { v in
-        \(arityRange.map { "\(indent(4))var results\($0) = C\($0).TangentVector()" }.joined(separator: "\n"))
+        \(arityRange.map { "\(indent(4))var results\($0) = C\($0).TangentVector(repeating: .zero, count: v.count)" }
+            .joined(separator: "\n"))
 
-        \(arityRange.map { "\(indent(4))results\($0).reserveCapacity(v.count)" }.joined(separator: "\n"))
+        \(arityRange.map { "\(indent(4))var results\($0)Index = results\($0).startIndex" }.joined(separator: "\n"))
 
                         // thoughts should Repeated tangentvector be a collection instead of also value + count alone? Will that make things easier?
                         // we can't do append on a Repeated object so we either have to generate it from a single scope or not at all
@@ -212,7 +213,10 @@ enum ZipSequenceGenerator {
         \(arityRange.map { "\(indent(6))result\($0)" }.joined(separator: ",\n"))
                             ) = pullback(tangentElement)
 
-        \(arityRange.map { "\(indent(5))results\($0).appendContribution(of: result\($0))" }.joined(separator: "\n"))
+        \(arityRange.map { "\(indent(5))results\($0).writeTangentContribution(of: result\($0), at: results\($0)Index)" }
+            .joined(separator: "\n"))
+
+        \(arityRange.map { "\(indent(5))results\($0).formIndex(after: &results\($0)Index)" }.joined(separator: "\n"))
                         }
 
                         return TangentVector(

--- a/DifferentiableZipCodeGenerator/Sources/DifferentiableZipCodeGenerator/ZipWithGenerator.swift
+++ b/DifferentiableZipCodeGenerator/Sources/DifferentiableZipCodeGenerator/ZipWithGenerator.swift
@@ -114,18 +114,14 @@ enum ZipWithGenerator {
                 pullback: { v in
                     precondition(v.count == pullbacks.count)
 
-        """
-        code += arityRange.map {
-            """
-            \(indent(3))var results\($0) = C\($0).TangentVector()
-            \(indent(3))results\($0).reserveCapacity(v.count)
-            """
-        }.joined(separator: "\n")
-        code += """
+        \(arityRange.map { "\(indent(3))var results\($0) = C\($0).TangentVector(repeating: .zero, count: v.count)" }
+            .joined(separator: "\n"))
+        \(arityRange.map { "\(indent(3))var results\($0)Index = results\($0).startIndex" }.joined(separator: "\n"))
 
                     for (tangentElement, pullback) in zip(v, pullbacks) {
                         let (\(arityRange.map { "v\($0)" }.joined(separator: ", "))) = pullback(tangentElement)
-        \(arityRange.map { "\(indent(4))results\($0).appendContribution(of: v\($0))" }.joined(separator: "\n"))
+        \(arityRange.map { "\(indent(4))results\($0).writeTangentContribution(of: v\($0), at: results\($0)Index)" }.joined(separator: "\n"))
+        \(arityRange.map { "\(indent(4))results\($0).formIndex(after: &results\($0)Index)" }.joined(separator: "\n"))
                     }
 
                     return (

--- a/DifferentiableZipCodeGenerator/Sources/DifferentiableZipCodeGenerator/ZipWithInoutGenerator.swift
+++ b/DifferentiableZipCodeGenerator/Sources/DifferentiableZipCodeGenerator/ZipWithInoutGenerator.swift
@@ -127,19 +127,15 @@ enum ZipWithInoutGenerator {
                 pullback: { v in
                     precondition(v.count == pullbacks.count)
 
-        """
-        code += arityRange.map {
-            """
-            \(indent(3))var results\($0) = C\($0).TangentVector()
-            \(indent(3))results\($0).reserveCapacity(v.count)
-            """
-        }.joined(separator: "\n")
-        code += """
+        \(arityRange.map { "\(indent(3))var results\($0) = C\($0).TangentVector(repeating: .zero, count: v.count)" }
+            .joined(separator: "\n"))
+        \(arityRange.map { "\(indent(3))var results\($0)Index = results\($0).startIndex" }.joined(separator: "\n"))
 
                     for (index, (tangentElement, pullback)) in zip(v.indices, zip(v, pullbacks)) {
                         let (v1, \(arityRange.map { "v\($0)" }.joined(separator: ", "))) = pullback(tangentElement)
                         v[index] = v1
-        \(arityRange.map { "\(indent(4))results\($0).appendContribution(of: v\($0))" }.joined(separator: "\n"))
+        \(arityRange.map { "\(indent(4))results\($0).writeTangentContribution(of: v\($0), at: results\($0)Index)" }.joined(separator: "\n"))
+        \(arityRange.map { "\(indent(4))results\($0).formIndex(after: &results\($0)Index)" }.joined(separator: "\n"))
                     }
 
                     // swiftformat:disable:next redundantParens

--- a/Sources/Differentiation/DifferentiableCollection.swift
+++ b/Sources/Differentiation/DifferentiableCollection.swift
@@ -12,9 +12,8 @@ public protocol DifferentiableCollection: Differentiable & Collection where
 }
 
 public protocol DifferentiableCollectionTangentVector: DifferentiableCollection {
-    init()
-    mutating func reserveCapacity(_ capacity: Int)
-    mutating func appendContribution(of value: Element)
+    init(repeating value: Element, count: Int)
+    mutating func writeTangentContribution(of value: Element, at index: Index)
 }
 
 extension Array: DifferentiableCollection where Element: Differentiable & AdditiveArithmetic {}
@@ -22,8 +21,9 @@ extension Array: DifferentiableCollection where Element: Differentiable & Additi
 extension Array.DifferentiableView: DifferentiableCollection where Element: AdditiveArithmetic {}
 
 extension Array.DifferentiableView: DifferentiableCollectionTangentVector where Element: AdditiveArithmetic {
-    public mutating func appendContribution(of value: Element) {
-        self.append(value)
+    @inlinable
+    public mutating func writeTangentContribution(of value: Element, at index: Index) {
+        self[index] += value
     }
 }
 
@@ -32,12 +32,15 @@ extension Repeated: DifferentiableCollection where Element: Differentiable & Add
 extension Repeated.DifferentiableView: DifferentiableCollection where Element: AdditiveArithmetic {}
 
 extension Repeated.DifferentiableView: DifferentiableCollectionTangentVector where Element: AdditiveArithmetic {
-    public init() { self = .zero }
-    public mutating func reserveCapacity(_: Int) { /* no-op */ }
-    public mutating func appendContribution(of value: Repeated<Element>.Element) {
+    @inlinable
+    public init(repeating value: Element, count: Int) {
+        self = .init(base: repeatElement(value, count: count))
+    }
+
+    @inlinable
+    public mutating func writeTangentContribution(of value: Repeated<Element>.Element, at _: Repeated<Element>.Index) {
         let newValue = self.base.repeatedValue + value
-        let newCount = self.base.count + 1
-        self.base = repeatElement(newValue, count: newCount)
+        self.base = repeatElement(newValue, count: self.count)
     }
 }
 

--- a/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity10.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity10.swift
@@ -433,27 +433,27 @@ extension Zip10SequenceDifferentiable: Differentiable where
         return (
             value: results,
             pullback: { v in
-                var results1 = C1.TangentVector()
-                var results2 = C2.TangentVector()
-                var results3 = C3.TangentVector()
-                var results4 = C4.TangentVector()
-                var results5 = C5.TangentVector()
-                var results6 = C6.TangentVector()
-                var results7 = C7.TangentVector()
-                var results8 = C8.TangentVector()
-                var results9 = C9.TangentVector()
-                var results10 = C10.TangentVector()
+                var results1 = C1.TangentVector(repeating: .zero, count: v.count)
+                var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+                var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+                var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+                var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+                var results6 = C6.TangentVector(repeating: .zero, count: v.count)
+                var results7 = C7.TangentVector(repeating: .zero, count: v.count)
+                var results8 = C8.TangentVector(repeating: .zero, count: v.count)
+                var results9 = C9.TangentVector(repeating: .zero, count: v.count)
+                var results10 = C10.TangentVector(repeating: .zero, count: v.count)
 
-                results1.reserveCapacity(v.count)
-                results2.reserveCapacity(v.count)
-                results3.reserveCapacity(v.count)
-                results4.reserveCapacity(v.count)
-                results5.reserveCapacity(v.count)
-                results6.reserveCapacity(v.count)
-                results7.reserveCapacity(v.count)
-                results8.reserveCapacity(v.count)
-                results9.reserveCapacity(v.count)
-                results10.reserveCapacity(v.count)
+                var results1Index = results1.startIndex
+                var results2Index = results2.startIndex
+                var results3Index = results3.startIndex
+                var results4Index = results4.startIndex
+                var results5Index = results5.startIndex
+                var results6Index = results6.startIndex
+                var results7Index = results7.startIndex
+                var results8Index = results8.startIndex
+                var results9Index = results9.startIndex
+                var results10Index = results10.startIndex
 
                 // thoughts should Repeated tangentvector be a collection instead of also value + count alone? Will that make things easier?
                 // we can't do append on a Repeated object so we either have to generate it from a single scope or not at all
@@ -473,16 +473,27 @@ extension Zip10SequenceDifferentiable: Differentiable where
                         result10
                     ) = pullback(tangentElement)
 
-                    results1.appendContribution(of: result1)
-                    results2.appendContribution(of: result2)
-                    results3.appendContribution(of: result3)
-                    results4.appendContribution(of: result4)
-                    results5.appendContribution(of: result5)
-                    results6.appendContribution(of: result6)
-                    results7.appendContribution(of: result7)
-                    results8.appendContribution(of: result8)
-                    results9.appendContribution(of: result9)
-                    results10.appendContribution(of: result10)
+                    results1.writeTangentContribution(of: result1, at: results1Index)
+                    results2.writeTangentContribution(of: result2, at: results2Index)
+                    results3.writeTangentContribution(of: result3, at: results3Index)
+                    results4.writeTangentContribution(of: result4, at: results4Index)
+                    results5.writeTangentContribution(of: result5, at: results5Index)
+                    results6.writeTangentContribution(of: result6, at: results6Index)
+                    results7.writeTangentContribution(of: result7, at: results7Index)
+                    results8.writeTangentContribution(of: result8, at: results8Index)
+                    results9.writeTangentContribution(of: result9, at: results9Index)
+                    results10.writeTangentContribution(of: result10, at: results10Index)
+
+                    results1.formIndex(after: &results1Index)
+                    results2.formIndex(after: &results2Index)
+                    results3.formIndex(after: &results3Index)
+                    results4.formIndex(after: &results4Index)
+                    results5.formIndex(after: &results5Index)
+                    results6.formIndex(after: &results6Index)
+                    results7.formIndex(after: &results7Index)
+                    results8.formIndex(after: &results8Index)
+                    results9.formIndex(after: &results9Index)
+                    results10.formIndex(after: &results10Index)
                 }
 
                 return TangentVector(

--- a/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity11.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity11.swift
@@ -465,29 +465,29 @@ extension Zip11SequenceDifferentiable: Differentiable where
         return (
             value: results,
             pullback: { v in
-                var results1 = C1.TangentVector()
-                var results2 = C2.TangentVector()
-                var results3 = C3.TangentVector()
-                var results4 = C4.TangentVector()
-                var results5 = C5.TangentVector()
-                var results6 = C6.TangentVector()
-                var results7 = C7.TangentVector()
-                var results8 = C8.TangentVector()
-                var results9 = C9.TangentVector()
-                var results10 = C10.TangentVector()
-                var results11 = C11.TangentVector()
+                var results1 = C1.TangentVector(repeating: .zero, count: v.count)
+                var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+                var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+                var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+                var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+                var results6 = C6.TangentVector(repeating: .zero, count: v.count)
+                var results7 = C7.TangentVector(repeating: .zero, count: v.count)
+                var results8 = C8.TangentVector(repeating: .zero, count: v.count)
+                var results9 = C9.TangentVector(repeating: .zero, count: v.count)
+                var results10 = C10.TangentVector(repeating: .zero, count: v.count)
+                var results11 = C11.TangentVector(repeating: .zero, count: v.count)
 
-                results1.reserveCapacity(v.count)
-                results2.reserveCapacity(v.count)
-                results3.reserveCapacity(v.count)
-                results4.reserveCapacity(v.count)
-                results5.reserveCapacity(v.count)
-                results6.reserveCapacity(v.count)
-                results7.reserveCapacity(v.count)
-                results8.reserveCapacity(v.count)
-                results9.reserveCapacity(v.count)
-                results10.reserveCapacity(v.count)
-                results11.reserveCapacity(v.count)
+                var results1Index = results1.startIndex
+                var results2Index = results2.startIndex
+                var results3Index = results3.startIndex
+                var results4Index = results4.startIndex
+                var results5Index = results5.startIndex
+                var results6Index = results6.startIndex
+                var results7Index = results7.startIndex
+                var results8Index = results8.startIndex
+                var results9Index = results9.startIndex
+                var results10Index = results10.startIndex
+                var results11Index = results11.startIndex
 
                 // thoughts should Repeated tangentvector be a collection instead of also value + count alone? Will that make things easier?
                 // we can't do append on a Repeated object so we either have to generate it from a single scope or not at all
@@ -508,17 +508,29 @@ extension Zip11SequenceDifferentiable: Differentiable where
                         result11
                     ) = pullback(tangentElement)
 
-                    results1.appendContribution(of: result1)
-                    results2.appendContribution(of: result2)
-                    results3.appendContribution(of: result3)
-                    results4.appendContribution(of: result4)
-                    results5.appendContribution(of: result5)
-                    results6.appendContribution(of: result6)
-                    results7.appendContribution(of: result7)
-                    results8.appendContribution(of: result8)
-                    results9.appendContribution(of: result9)
-                    results10.appendContribution(of: result10)
-                    results11.appendContribution(of: result11)
+                    results1.writeTangentContribution(of: result1, at: results1Index)
+                    results2.writeTangentContribution(of: result2, at: results2Index)
+                    results3.writeTangentContribution(of: result3, at: results3Index)
+                    results4.writeTangentContribution(of: result4, at: results4Index)
+                    results5.writeTangentContribution(of: result5, at: results5Index)
+                    results6.writeTangentContribution(of: result6, at: results6Index)
+                    results7.writeTangentContribution(of: result7, at: results7Index)
+                    results8.writeTangentContribution(of: result8, at: results8Index)
+                    results9.writeTangentContribution(of: result9, at: results9Index)
+                    results10.writeTangentContribution(of: result10, at: results10Index)
+                    results11.writeTangentContribution(of: result11, at: results11Index)
+
+                    results1.formIndex(after: &results1Index)
+                    results2.formIndex(after: &results2Index)
+                    results3.formIndex(after: &results3Index)
+                    results4.formIndex(after: &results4Index)
+                    results5.formIndex(after: &results5Index)
+                    results6.formIndex(after: &results6Index)
+                    results7.formIndex(after: &results7Index)
+                    results8.formIndex(after: &results8Index)
+                    results9.formIndex(after: &results9Index)
+                    results10.formIndex(after: &results10Index)
+                    results11.formIndex(after: &results11Index)
                 }
 
                 return TangentVector(

--- a/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity12.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity12.swift
@@ -497,31 +497,31 @@ extension Zip12SequenceDifferentiable: Differentiable where
         return (
             value: results,
             pullback: { v in
-                var results1 = C1.TangentVector()
-                var results2 = C2.TangentVector()
-                var results3 = C3.TangentVector()
-                var results4 = C4.TangentVector()
-                var results5 = C5.TangentVector()
-                var results6 = C6.TangentVector()
-                var results7 = C7.TangentVector()
-                var results8 = C8.TangentVector()
-                var results9 = C9.TangentVector()
-                var results10 = C10.TangentVector()
-                var results11 = C11.TangentVector()
-                var results12 = C12.TangentVector()
+                var results1 = C1.TangentVector(repeating: .zero, count: v.count)
+                var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+                var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+                var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+                var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+                var results6 = C6.TangentVector(repeating: .zero, count: v.count)
+                var results7 = C7.TangentVector(repeating: .zero, count: v.count)
+                var results8 = C8.TangentVector(repeating: .zero, count: v.count)
+                var results9 = C9.TangentVector(repeating: .zero, count: v.count)
+                var results10 = C10.TangentVector(repeating: .zero, count: v.count)
+                var results11 = C11.TangentVector(repeating: .zero, count: v.count)
+                var results12 = C12.TangentVector(repeating: .zero, count: v.count)
 
-                results1.reserveCapacity(v.count)
-                results2.reserveCapacity(v.count)
-                results3.reserveCapacity(v.count)
-                results4.reserveCapacity(v.count)
-                results5.reserveCapacity(v.count)
-                results6.reserveCapacity(v.count)
-                results7.reserveCapacity(v.count)
-                results8.reserveCapacity(v.count)
-                results9.reserveCapacity(v.count)
-                results10.reserveCapacity(v.count)
-                results11.reserveCapacity(v.count)
-                results12.reserveCapacity(v.count)
+                var results1Index = results1.startIndex
+                var results2Index = results2.startIndex
+                var results3Index = results3.startIndex
+                var results4Index = results4.startIndex
+                var results5Index = results5.startIndex
+                var results6Index = results6.startIndex
+                var results7Index = results7.startIndex
+                var results8Index = results8.startIndex
+                var results9Index = results9.startIndex
+                var results10Index = results10.startIndex
+                var results11Index = results11.startIndex
+                var results12Index = results12.startIndex
 
                 // thoughts should Repeated tangentvector be a collection instead of also value + count alone? Will that make things easier?
                 // we can't do append on a Repeated object so we either have to generate it from a single scope or not at all
@@ -543,18 +543,31 @@ extension Zip12SequenceDifferentiable: Differentiable where
                         result12
                     ) = pullback(tangentElement)
 
-                    results1.appendContribution(of: result1)
-                    results2.appendContribution(of: result2)
-                    results3.appendContribution(of: result3)
-                    results4.appendContribution(of: result4)
-                    results5.appendContribution(of: result5)
-                    results6.appendContribution(of: result6)
-                    results7.appendContribution(of: result7)
-                    results8.appendContribution(of: result8)
-                    results9.appendContribution(of: result9)
-                    results10.appendContribution(of: result10)
-                    results11.appendContribution(of: result11)
-                    results12.appendContribution(of: result12)
+                    results1.writeTangentContribution(of: result1, at: results1Index)
+                    results2.writeTangentContribution(of: result2, at: results2Index)
+                    results3.writeTangentContribution(of: result3, at: results3Index)
+                    results4.writeTangentContribution(of: result4, at: results4Index)
+                    results5.writeTangentContribution(of: result5, at: results5Index)
+                    results6.writeTangentContribution(of: result6, at: results6Index)
+                    results7.writeTangentContribution(of: result7, at: results7Index)
+                    results8.writeTangentContribution(of: result8, at: results8Index)
+                    results9.writeTangentContribution(of: result9, at: results9Index)
+                    results10.writeTangentContribution(of: result10, at: results10Index)
+                    results11.writeTangentContribution(of: result11, at: results11Index)
+                    results12.writeTangentContribution(of: result12, at: results12Index)
+
+                    results1.formIndex(after: &results1Index)
+                    results2.formIndex(after: &results2Index)
+                    results3.formIndex(after: &results3Index)
+                    results4.formIndex(after: &results4Index)
+                    results5.formIndex(after: &results5Index)
+                    results6.formIndex(after: &results6Index)
+                    results7.formIndex(after: &results7Index)
+                    results8.formIndex(after: &results8Index)
+                    results9.formIndex(after: &results9Index)
+                    results10.formIndex(after: &results10Index)
+                    results11.formIndex(after: &results11Index)
+                    results12.formIndex(after: &results12Index)
                 }
 
                 return TangentVector(

--- a/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity13.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity13.swift
@@ -529,33 +529,33 @@ extension Zip13SequenceDifferentiable: Differentiable where
         return (
             value: results,
             pullback: { v in
-                var results1 = C1.TangentVector()
-                var results2 = C2.TangentVector()
-                var results3 = C3.TangentVector()
-                var results4 = C4.TangentVector()
-                var results5 = C5.TangentVector()
-                var results6 = C6.TangentVector()
-                var results7 = C7.TangentVector()
-                var results8 = C8.TangentVector()
-                var results9 = C9.TangentVector()
-                var results10 = C10.TangentVector()
-                var results11 = C11.TangentVector()
-                var results12 = C12.TangentVector()
-                var results13 = C13.TangentVector()
+                var results1 = C1.TangentVector(repeating: .zero, count: v.count)
+                var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+                var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+                var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+                var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+                var results6 = C6.TangentVector(repeating: .zero, count: v.count)
+                var results7 = C7.TangentVector(repeating: .zero, count: v.count)
+                var results8 = C8.TangentVector(repeating: .zero, count: v.count)
+                var results9 = C9.TangentVector(repeating: .zero, count: v.count)
+                var results10 = C10.TangentVector(repeating: .zero, count: v.count)
+                var results11 = C11.TangentVector(repeating: .zero, count: v.count)
+                var results12 = C12.TangentVector(repeating: .zero, count: v.count)
+                var results13 = C13.TangentVector(repeating: .zero, count: v.count)
 
-                results1.reserveCapacity(v.count)
-                results2.reserveCapacity(v.count)
-                results3.reserveCapacity(v.count)
-                results4.reserveCapacity(v.count)
-                results5.reserveCapacity(v.count)
-                results6.reserveCapacity(v.count)
-                results7.reserveCapacity(v.count)
-                results8.reserveCapacity(v.count)
-                results9.reserveCapacity(v.count)
-                results10.reserveCapacity(v.count)
-                results11.reserveCapacity(v.count)
-                results12.reserveCapacity(v.count)
-                results13.reserveCapacity(v.count)
+                var results1Index = results1.startIndex
+                var results2Index = results2.startIndex
+                var results3Index = results3.startIndex
+                var results4Index = results4.startIndex
+                var results5Index = results5.startIndex
+                var results6Index = results6.startIndex
+                var results7Index = results7.startIndex
+                var results8Index = results8.startIndex
+                var results9Index = results9.startIndex
+                var results10Index = results10.startIndex
+                var results11Index = results11.startIndex
+                var results12Index = results12.startIndex
+                var results13Index = results13.startIndex
 
                 // thoughts should Repeated tangentvector be a collection instead of also value + count alone? Will that make things easier?
                 // we can't do append on a Repeated object so we either have to generate it from a single scope or not at all
@@ -578,19 +578,33 @@ extension Zip13SequenceDifferentiable: Differentiable where
                         result13
                     ) = pullback(tangentElement)
 
-                    results1.appendContribution(of: result1)
-                    results2.appendContribution(of: result2)
-                    results3.appendContribution(of: result3)
-                    results4.appendContribution(of: result4)
-                    results5.appendContribution(of: result5)
-                    results6.appendContribution(of: result6)
-                    results7.appendContribution(of: result7)
-                    results8.appendContribution(of: result8)
-                    results9.appendContribution(of: result9)
-                    results10.appendContribution(of: result10)
-                    results11.appendContribution(of: result11)
-                    results12.appendContribution(of: result12)
-                    results13.appendContribution(of: result13)
+                    results1.writeTangentContribution(of: result1, at: results1Index)
+                    results2.writeTangentContribution(of: result2, at: results2Index)
+                    results3.writeTangentContribution(of: result3, at: results3Index)
+                    results4.writeTangentContribution(of: result4, at: results4Index)
+                    results5.writeTangentContribution(of: result5, at: results5Index)
+                    results6.writeTangentContribution(of: result6, at: results6Index)
+                    results7.writeTangentContribution(of: result7, at: results7Index)
+                    results8.writeTangentContribution(of: result8, at: results8Index)
+                    results9.writeTangentContribution(of: result9, at: results9Index)
+                    results10.writeTangentContribution(of: result10, at: results10Index)
+                    results11.writeTangentContribution(of: result11, at: results11Index)
+                    results12.writeTangentContribution(of: result12, at: results12Index)
+                    results13.writeTangentContribution(of: result13, at: results13Index)
+
+                    results1.formIndex(after: &results1Index)
+                    results2.formIndex(after: &results2Index)
+                    results3.formIndex(after: &results3Index)
+                    results4.formIndex(after: &results4Index)
+                    results5.formIndex(after: &results5Index)
+                    results6.formIndex(after: &results6Index)
+                    results7.formIndex(after: &results7Index)
+                    results8.formIndex(after: &results8Index)
+                    results9.formIndex(after: &results9Index)
+                    results10.formIndex(after: &results10Index)
+                    results11.formIndex(after: &results11Index)
+                    results12.formIndex(after: &results12Index)
+                    results13.formIndex(after: &results13Index)
                 }
 
                 return TangentVector(

--- a/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity14.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity14.swift
@@ -561,35 +561,35 @@ extension Zip14SequenceDifferentiable: Differentiable where
         return (
             value: results,
             pullback: { v in
-                var results1 = C1.TangentVector()
-                var results2 = C2.TangentVector()
-                var results3 = C3.TangentVector()
-                var results4 = C4.TangentVector()
-                var results5 = C5.TangentVector()
-                var results6 = C6.TangentVector()
-                var results7 = C7.TangentVector()
-                var results8 = C8.TangentVector()
-                var results9 = C9.TangentVector()
-                var results10 = C10.TangentVector()
-                var results11 = C11.TangentVector()
-                var results12 = C12.TangentVector()
-                var results13 = C13.TangentVector()
-                var results14 = C14.TangentVector()
+                var results1 = C1.TangentVector(repeating: .zero, count: v.count)
+                var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+                var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+                var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+                var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+                var results6 = C6.TangentVector(repeating: .zero, count: v.count)
+                var results7 = C7.TangentVector(repeating: .zero, count: v.count)
+                var results8 = C8.TangentVector(repeating: .zero, count: v.count)
+                var results9 = C9.TangentVector(repeating: .zero, count: v.count)
+                var results10 = C10.TangentVector(repeating: .zero, count: v.count)
+                var results11 = C11.TangentVector(repeating: .zero, count: v.count)
+                var results12 = C12.TangentVector(repeating: .zero, count: v.count)
+                var results13 = C13.TangentVector(repeating: .zero, count: v.count)
+                var results14 = C14.TangentVector(repeating: .zero, count: v.count)
 
-                results1.reserveCapacity(v.count)
-                results2.reserveCapacity(v.count)
-                results3.reserveCapacity(v.count)
-                results4.reserveCapacity(v.count)
-                results5.reserveCapacity(v.count)
-                results6.reserveCapacity(v.count)
-                results7.reserveCapacity(v.count)
-                results8.reserveCapacity(v.count)
-                results9.reserveCapacity(v.count)
-                results10.reserveCapacity(v.count)
-                results11.reserveCapacity(v.count)
-                results12.reserveCapacity(v.count)
-                results13.reserveCapacity(v.count)
-                results14.reserveCapacity(v.count)
+                var results1Index = results1.startIndex
+                var results2Index = results2.startIndex
+                var results3Index = results3.startIndex
+                var results4Index = results4.startIndex
+                var results5Index = results5.startIndex
+                var results6Index = results6.startIndex
+                var results7Index = results7.startIndex
+                var results8Index = results8.startIndex
+                var results9Index = results9.startIndex
+                var results10Index = results10.startIndex
+                var results11Index = results11.startIndex
+                var results12Index = results12.startIndex
+                var results13Index = results13.startIndex
+                var results14Index = results14.startIndex
 
                 // thoughts should Repeated tangentvector be a collection instead of also value + count alone? Will that make things easier?
                 // we can't do append on a Repeated object so we either have to generate it from a single scope or not at all
@@ -613,20 +613,35 @@ extension Zip14SequenceDifferentiable: Differentiable where
                         result14
                     ) = pullback(tangentElement)
 
-                    results1.appendContribution(of: result1)
-                    results2.appendContribution(of: result2)
-                    results3.appendContribution(of: result3)
-                    results4.appendContribution(of: result4)
-                    results5.appendContribution(of: result5)
-                    results6.appendContribution(of: result6)
-                    results7.appendContribution(of: result7)
-                    results8.appendContribution(of: result8)
-                    results9.appendContribution(of: result9)
-                    results10.appendContribution(of: result10)
-                    results11.appendContribution(of: result11)
-                    results12.appendContribution(of: result12)
-                    results13.appendContribution(of: result13)
-                    results14.appendContribution(of: result14)
+                    results1.writeTangentContribution(of: result1, at: results1Index)
+                    results2.writeTangentContribution(of: result2, at: results2Index)
+                    results3.writeTangentContribution(of: result3, at: results3Index)
+                    results4.writeTangentContribution(of: result4, at: results4Index)
+                    results5.writeTangentContribution(of: result5, at: results5Index)
+                    results6.writeTangentContribution(of: result6, at: results6Index)
+                    results7.writeTangentContribution(of: result7, at: results7Index)
+                    results8.writeTangentContribution(of: result8, at: results8Index)
+                    results9.writeTangentContribution(of: result9, at: results9Index)
+                    results10.writeTangentContribution(of: result10, at: results10Index)
+                    results11.writeTangentContribution(of: result11, at: results11Index)
+                    results12.writeTangentContribution(of: result12, at: results12Index)
+                    results13.writeTangentContribution(of: result13, at: results13Index)
+                    results14.writeTangentContribution(of: result14, at: results14Index)
+
+                    results1.formIndex(after: &results1Index)
+                    results2.formIndex(after: &results2Index)
+                    results3.formIndex(after: &results3Index)
+                    results4.formIndex(after: &results4Index)
+                    results5.formIndex(after: &results5Index)
+                    results6.formIndex(after: &results6Index)
+                    results7.formIndex(after: &results7Index)
+                    results8.formIndex(after: &results8Index)
+                    results9.formIndex(after: &results9Index)
+                    results10.formIndex(after: &results10Index)
+                    results11.formIndex(after: &results11Index)
+                    results12.formIndex(after: &results12Index)
+                    results13.formIndex(after: &results13Index)
+                    results14.formIndex(after: &results14Index)
                 }
 
                 return TangentVector(

--- a/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity2.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity2.swift
@@ -177,11 +177,11 @@ extension Zip2SequenceDifferentiable: Differentiable where
         return (
             value: results,
             pullback: { v in
-                var results1 = C1.TangentVector()
-                var results2 = C2.TangentVector()
+                var results1 = C1.TangentVector(repeating: .zero, count: v.count)
+                var results2 = C2.TangentVector(repeating: .zero, count: v.count)
 
-                results1.reserveCapacity(v.count)
-                results2.reserveCapacity(v.count)
+                var results1Index = results1.startIndex
+                var results2Index = results2.startIndex
 
                 // thoughts should Repeated tangentvector be a collection instead of also value + count alone? Will that make things easier?
                 // we can't do append on a Repeated object so we either have to generate it from a single scope or not at all
@@ -193,8 +193,11 @@ extension Zip2SequenceDifferentiable: Differentiable where
                         result2
                     ) = pullback(tangentElement)
 
-                    results1.appendContribution(of: result1)
-                    results2.appendContribution(of: result2)
+                    results1.writeTangentContribution(of: result1, at: results1Index)
+                    results2.writeTangentContribution(of: result2, at: results2Index)
+
+                    results1.formIndex(after: &results1Index)
+                    results2.formIndex(after: &results2Index)
                 }
 
                 return TangentVector(

--- a/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity3.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity3.swift
@@ -209,13 +209,13 @@ extension Zip3SequenceDifferentiable: Differentiable where
         return (
             value: results,
             pullback: { v in
-                var results1 = C1.TangentVector()
-                var results2 = C2.TangentVector()
-                var results3 = C3.TangentVector()
+                var results1 = C1.TangentVector(repeating: .zero, count: v.count)
+                var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+                var results3 = C3.TangentVector(repeating: .zero, count: v.count)
 
-                results1.reserveCapacity(v.count)
-                results2.reserveCapacity(v.count)
-                results3.reserveCapacity(v.count)
+                var results1Index = results1.startIndex
+                var results2Index = results2.startIndex
+                var results3Index = results3.startIndex
 
                 // thoughts should Repeated tangentvector be a collection instead of also value + count alone? Will that make things easier?
                 // we can't do append on a Repeated object so we either have to generate it from a single scope or not at all
@@ -228,9 +228,13 @@ extension Zip3SequenceDifferentiable: Differentiable where
                         result3
                     ) = pullback(tangentElement)
 
-                    results1.appendContribution(of: result1)
-                    results2.appendContribution(of: result2)
-                    results3.appendContribution(of: result3)
+                    results1.writeTangentContribution(of: result1, at: results1Index)
+                    results2.writeTangentContribution(of: result2, at: results2Index)
+                    results3.writeTangentContribution(of: result3, at: results3Index)
+
+                    results1.formIndex(after: &results1Index)
+                    results2.formIndex(after: &results2Index)
+                    results3.formIndex(after: &results3Index)
                 }
 
                 return TangentVector(

--- a/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity4.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity4.swift
@@ -241,15 +241,15 @@ extension Zip4SequenceDifferentiable: Differentiable where
         return (
             value: results,
             pullback: { v in
-                var results1 = C1.TangentVector()
-                var results2 = C2.TangentVector()
-                var results3 = C3.TangentVector()
-                var results4 = C4.TangentVector()
+                var results1 = C1.TangentVector(repeating: .zero, count: v.count)
+                var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+                var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+                var results4 = C4.TangentVector(repeating: .zero, count: v.count)
 
-                results1.reserveCapacity(v.count)
-                results2.reserveCapacity(v.count)
-                results3.reserveCapacity(v.count)
-                results4.reserveCapacity(v.count)
+                var results1Index = results1.startIndex
+                var results2Index = results2.startIndex
+                var results3Index = results3.startIndex
+                var results4Index = results4.startIndex
 
                 // thoughts should Repeated tangentvector be a collection instead of also value + count alone? Will that make things easier?
                 // we can't do append on a Repeated object so we either have to generate it from a single scope or not at all
@@ -263,10 +263,15 @@ extension Zip4SequenceDifferentiable: Differentiable where
                         result4
                     ) = pullback(tangentElement)
 
-                    results1.appendContribution(of: result1)
-                    results2.appendContribution(of: result2)
-                    results3.appendContribution(of: result3)
-                    results4.appendContribution(of: result4)
+                    results1.writeTangentContribution(of: result1, at: results1Index)
+                    results2.writeTangentContribution(of: result2, at: results2Index)
+                    results3.writeTangentContribution(of: result3, at: results3Index)
+                    results4.writeTangentContribution(of: result4, at: results4Index)
+
+                    results1.formIndex(after: &results1Index)
+                    results2.formIndex(after: &results2Index)
+                    results3.formIndex(after: &results3Index)
+                    results4.formIndex(after: &results4Index)
                 }
 
                 return TangentVector(

--- a/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity5.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity5.swift
@@ -273,17 +273,17 @@ extension Zip5SequenceDifferentiable: Differentiable where
         return (
             value: results,
             pullback: { v in
-                var results1 = C1.TangentVector()
-                var results2 = C2.TangentVector()
-                var results3 = C3.TangentVector()
-                var results4 = C4.TangentVector()
-                var results5 = C5.TangentVector()
+                var results1 = C1.TangentVector(repeating: .zero, count: v.count)
+                var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+                var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+                var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+                var results5 = C5.TangentVector(repeating: .zero, count: v.count)
 
-                results1.reserveCapacity(v.count)
-                results2.reserveCapacity(v.count)
-                results3.reserveCapacity(v.count)
-                results4.reserveCapacity(v.count)
-                results5.reserveCapacity(v.count)
+                var results1Index = results1.startIndex
+                var results2Index = results2.startIndex
+                var results3Index = results3.startIndex
+                var results4Index = results4.startIndex
+                var results5Index = results5.startIndex
 
                 // thoughts should Repeated tangentvector be a collection instead of also value + count alone? Will that make things easier?
                 // we can't do append on a Repeated object so we either have to generate it from a single scope or not at all
@@ -298,11 +298,17 @@ extension Zip5SequenceDifferentiable: Differentiable where
                         result5
                     ) = pullback(tangentElement)
 
-                    results1.appendContribution(of: result1)
-                    results2.appendContribution(of: result2)
-                    results3.appendContribution(of: result3)
-                    results4.appendContribution(of: result4)
-                    results5.appendContribution(of: result5)
+                    results1.writeTangentContribution(of: result1, at: results1Index)
+                    results2.writeTangentContribution(of: result2, at: results2Index)
+                    results3.writeTangentContribution(of: result3, at: results3Index)
+                    results4.writeTangentContribution(of: result4, at: results4Index)
+                    results5.writeTangentContribution(of: result5, at: results5Index)
+
+                    results1.formIndex(after: &results1Index)
+                    results2.formIndex(after: &results2Index)
+                    results3.formIndex(after: &results3Index)
+                    results4.formIndex(after: &results4Index)
+                    results5.formIndex(after: &results5Index)
                 }
 
                 return TangentVector(

--- a/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity6.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity6.swift
@@ -305,19 +305,19 @@ extension Zip6SequenceDifferentiable: Differentiable where
         return (
             value: results,
             pullback: { v in
-                var results1 = C1.TangentVector()
-                var results2 = C2.TangentVector()
-                var results3 = C3.TangentVector()
-                var results4 = C4.TangentVector()
-                var results5 = C5.TangentVector()
-                var results6 = C6.TangentVector()
+                var results1 = C1.TangentVector(repeating: .zero, count: v.count)
+                var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+                var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+                var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+                var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+                var results6 = C6.TangentVector(repeating: .zero, count: v.count)
 
-                results1.reserveCapacity(v.count)
-                results2.reserveCapacity(v.count)
-                results3.reserveCapacity(v.count)
-                results4.reserveCapacity(v.count)
-                results5.reserveCapacity(v.count)
-                results6.reserveCapacity(v.count)
+                var results1Index = results1.startIndex
+                var results2Index = results2.startIndex
+                var results3Index = results3.startIndex
+                var results4Index = results4.startIndex
+                var results5Index = results5.startIndex
+                var results6Index = results6.startIndex
 
                 // thoughts should Repeated tangentvector be a collection instead of also value + count alone? Will that make things easier?
                 // we can't do append on a Repeated object so we either have to generate it from a single scope or not at all
@@ -333,12 +333,19 @@ extension Zip6SequenceDifferentiable: Differentiable where
                         result6
                     ) = pullback(tangentElement)
 
-                    results1.appendContribution(of: result1)
-                    results2.appendContribution(of: result2)
-                    results3.appendContribution(of: result3)
-                    results4.appendContribution(of: result4)
-                    results5.appendContribution(of: result5)
-                    results6.appendContribution(of: result6)
+                    results1.writeTangentContribution(of: result1, at: results1Index)
+                    results2.writeTangentContribution(of: result2, at: results2Index)
+                    results3.writeTangentContribution(of: result3, at: results3Index)
+                    results4.writeTangentContribution(of: result4, at: results4Index)
+                    results5.writeTangentContribution(of: result5, at: results5Index)
+                    results6.writeTangentContribution(of: result6, at: results6Index)
+
+                    results1.formIndex(after: &results1Index)
+                    results2.formIndex(after: &results2Index)
+                    results3.formIndex(after: &results3Index)
+                    results4.formIndex(after: &results4Index)
+                    results5.formIndex(after: &results5Index)
+                    results6.formIndex(after: &results6Index)
                 }
 
                 return TangentVector(

--- a/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity7.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity7.swift
@@ -337,21 +337,21 @@ extension Zip7SequenceDifferentiable: Differentiable where
         return (
             value: results,
             pullback: { v in
-                var results1 = C1.TangentVector()
-                var results2 = C2.TangentVector()
-                var results3 = C3.TangentVector()
-                var results4 = C4.TangentVector()
-                var results5 = C5.TangentVector()
-                var results6 = C6.TangentVector()
-                var results7 = C7.TangentVector()
+                var results1 = C1.TangentVector(repeating: .zero, count: v.count)
+                var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+                var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+                var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+                var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+                var results6 = C6.TangentVector(repeating: .zero, count: v.count)
+                var results7 = C7.TangentVector(repeating: .zero, count: v.count)
 
-                results1.reserveCapacity(v.count)
-                results2.reserveCapacity(v.count)
-                results3.reserveCapacity(v.count)
-                results4.reserveCapacity(v.count)
-                results5.reserveCapacity(v.count)
-                results6.reserveCapacity(v.count)
-                results7.reserveCapacity(v.count)
+                var results1Index = results1.startIndex
+                var results2Index = results2.startIndex
+                var results3Index = results3.startIndex
+                var results4Index = results4.startIndex
+                var results5Index = results5.startIndex
+                var results6Index = results6.startIndex
+                var results7Index = results7.startIndex
 
                 // thoughts should Repeated tangentvector be a collection instead of also value + count alone? Will that make things easier?
                 // we can't do append on a Repeated object so we either have to generate it from a single scope or not at all
@@ -368,13 +368,21 @@ extension Zip7SequenceDifferentiable: Differentiable where
                         result7
                     ) = pullback(tangentElement)
 
-                    results1.appendContribution(of: result1)
-                    results2.appendContribution(of: result2)
-                    results3.appendContribution(of: result3)
-                    results4.appendContribution(of: result4)
-                    results5.appendContribution(of: result5)
-                    results6.appendContribution(of: result6)
-                    results7.appendContribution(of: result7)
+                    results1.writeTangentContribution(of: result1, at: results1Index)
+                    results2.writeTangentContribution(of: result2, at: results2Index)
+                    results3.writeTangentContribution(of: result3, at: results3Index)
+                    results4.writeTangentContribution(of: result4, at: results4Index)
+                    results5.writeTangentContribution(of: result5, at: results5Index)
+                    results6.writeTangentContribution(of: result6, at: results6Index)
+                    results7.writeTangentContribution(of: result7, at: results7Index)
+
+                    results1.formIndex(after: &results1Index)
+                    results2.formIndex(after: &results2Index)
+                    results3.formIndex(after: &results3Index)
+                    results4.formIndex(after: &results4Index)
+                    results5.formIndex(after: &results5Index)
+                    results6.formIndex(after: &results6Index)
+                    results7.formIndex(after: &results7Index)
                 }
 
                 return TangentVector(

--- a/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity8.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity8.swift
@@ -369,23 +369,23 @@ extension Zip8SequenceDifferentiable: Differentiable where
         return (
             value: results,
             pullback: { v in
-                var results1 = C1.TangentVector()
-                var results2 = C2.TangentVector()
-                var results3 = C3.TangentVector()
-                var results4 = C4.TangentVector()
-                var results5 = C5.TangentVector()
-                var results6 = C6.TangentVector()
-                var results7 = C7.TangentVector()
-                var results8 = C8.TangentVector()
+                var results1 = C1.TangentVector(repeating: .zero, count: v.count)
+                var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+                var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+                var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+                var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+                var results6 = C6.TangentVector(repeating: .zero, count: v.count)
+                var results7 = C7.TangentVector(repeating: .zero, count: v.count)
+                var results8 = C8.TangentVector(repeating: .zero, count: v.count)
 
-                results1.reserveCapacity(v.count)
-                results2.reserveCapacity(v.count)
-                results3.reserveCapacity(v.count)
-                results4.reserveCapacity(v.count)
-                results5.reserveCapacity(v.count)
-                results6.reserveCapacity(v.count)
-                results7.reserveCapacity(v.count)
-                results8.reserveCapacity(v.count)
+                var results1Index = results1.startIndex
+                var results2Index = results2.startIndex
+                var results3Index = results3.startIndex
+                var results4Index = results4.startIndex
+                var results5Index = results5.startIndex
+                var results6Index = results6.startIndex
+                var results7Index = results7.startIndex
+                var results8Index = results8.startIndex
 
                 // thoughts should Repeated tangentvector be a collection instead of also value + count alone? Will that make things easier?
                 // we can't do append on a Repeated object so we either have to generate it from a single scope or not at all
@@ -403,14 +403,23 @@ extension Zip8SequenceDifferentiable: Differentiable where
                         result8
                     ) = pullback(tangentElement)
 
-                    results1.appendContribution(of: result1)
-                    results2.appendContribution(of: result2)
-                    results3.appendContribution(of: result3)
-                    results4.appendContribution(of: result4)
-                    results5.appendContribution(of: result5)
-                    results6.appendContribution(of: result6)
-                    results7.appendContribution(of: result7)
-                    results8.appendContribution(of: result8)
+                    results1.writeTangentContribution(of: result1, at: results1Index)
+                    results2.writeTangentContribution(of: result2, at: results2Index)
+                    results3.writeTangentContribution(of: result3, at: results3Index)
+                    results4.writeTangentContribution(of: result4, at: results4Index)
+                    results5.writeTangentContribution(of: result5, at: results5Index)
+                    results6.writeTangentContribution(of: result6, at: results6Index)
+                    results7.writeTangentContribution(of: result7, at: results7Index)
+                    results8.writeTangentContribution(of: result8, at: results8Index)
+
+                    results1.formIndex(after: &results1Index)
+                    results2.formIndex(after: &results2Index)
+                    results3.formIndex(after: &results3Index)
+                    results4.formIndex(after: &results4Index)
+                    results5.formIndex(after: &results5Index)
+                    results6.formIndex(after: &results6Index)
+                    results7.formIndex(after: &results7Index)
+                    results8.formIndex(after: &results8Index)
                 }
 
                 return TangentVector(

--- a/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity9.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity9.swift
@@ -401,25 +401,25 @@ extension Zip9SequenceDifferentiable: Differentiable where
         return (
             value: results,
             pullback: { v in
-                var results1 = C1.TangentVector()
-                var results2 = C2.TangentVector()
-                var results3 = C3.TangentVector()
-                var results4 = C4.TangentVector()
-                var results5 = C5.TangentVector()
-                var results6 = C6.TangentVector()
-                var results7 = C7.TangentVector()
-                var results8 = C8.TangentVector()
-                var results9 = C9.TangentVector()
+                var results1 = C1.TangentVector(repeating: .zero, count: v.count)
+                var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+                var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+                var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+                var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+                var results6 = C6.TangentVector(repeating: .zero, count: v.count)
+                var results7 = C7.TangentVector(repeating: .zero, count: v.count)
+                var results8 = C8.TangentVector(repeating: .zero, count: v.count)
+                var results9 = C9.TangentVector(repeating: .zero, count: v.count)
 
-                results1.reserveCapacity(v.count)
-                results2.reserveCapacity(v.count)
-                results3.reserveCapacity(v.count)
-                results4.reserveCapacity(v.count)
-                results5.reserveCapacity(v.count)
-                results6.reserveCapacity(v.count)
-                results7.reserveCapacity(v.count)
-                results8.reserveCapacity(v.count)
-                results9.reserveCapacity(v.count)
+                var results1Index = results1.startIndex
+                var results2Index = results2.startIndex
+                var results3Index = results3.startIndex
+                var results4Index = results4.startIndex
+                var results5Index = results5.startIndex
+                var results6Index = results6.startIndex
+                var results7Index = results7.startIndex
+                var results8Index = results8.startIndex
+                var results9Index = results9.startIndex
 
                 // thoughts should Repeated tangentvector be a collection instead of also value + count alone? Will that make things easier?
                 // we can't do append on a Repeated object so we either have to generate it from a single scope or not at all
@@ -438,15 +438,25 @@ extension Zip9SequenceDifferentiable: Differentiable where
                         result9
                     ) = pullback(tangentElement)
 
-                    results1.appendContribution(of: result1)
-                    results2.appendContribution(of: result2)
-                    results3.appendContribution(of: result3)
-                    results4.appendContribution(of: result4)
-                    results5.appendContribution(of: result5)
-                    results6.appendContribution(of: result6)
-                    results7.appendContribution(of: result7)
-                    results8.appendContribution(of: result8)
-                    results9.appendContribution(of: result9)
+                    results1.writeTangentContribution(of: result1, at: results1Index)
+                    results2.writeTangentContribution(of: result2, at: results2Index)
+                    results3.writeTangentContribution(of: result3, at: results3Index)
+                    results4.writeTangentContribution(of: result4, at: results4Index)
+                    results5.writeTangentContribution(of: result5, at: results5Index)
+                    results6.writeTangentContribution(of: result6, at: results6Index)
+                    results7.writeTangentContribution(of: result7, at: results7Index)
+                    results8.writeTangentContribution(of: result8, at: results8Index)
+                    results9.writeTangentContribution(of: result9, at: results9Index)
+
+                    results1.formIndex(after: &results1Index)
+                    results2.formIndex(after: &results2Index)
+                    results3.formIndex(after: &results3Index)
+                    results4.formIndex(after: &results4Index)
+                    results5.formIndex(after: &results5Index)
+                    results6.formIndex(after: &results6Index)
+                    results7.formIndex(after: &results7Index)
+                    results8.formIndex(after: &results8Index)
+                    results9.formIndex(after: &results9Index)
                 }
 
                 return TangentVector(

--- a/Sources/Differentiation/DifferentiableZip/ZipWith+Arity10.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWith+Arity10.swift
@@ -263,38 +263,50 @@ public func _vjpDifferentiableZipWith<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, R
         value: Array(results),
         pullback: { v in
             precondition(v.count == pullbacks.count)
-            var results1 = C1.TangentVector()
-            results1.reserveCapacity(v.count)
-            var results2 = C2.TangentVector()
-            results2.reserveCapacity(v.count)
-            var results3 = C3.TangentVector()
-            results3.reserveCapacity(v.count)
-            var results4 = C4.TangentVector()
-            results4.reserveCapacity(v.count)
-            var results5 = C5.TangentVector()
-            results5.reserveCapacity(v.count)
-            var results6 = C6.TangentVector()
-            results6.reserveCapacity(v.count)
-            var results7 = C7.TangentVector()
-            results7.reserveCapacity(v.count)
-            var results8 = C8.TangentVector()
-            results8.reserveCapacity(v.count)
-            var results9 = C9.TangentVector()
-            results9.reserveCapacity(v.count)
-            var results10 = C10.TangentVector()
-            results10.reserveCapacity(v.count)
+
+            var results1 = C1.TangentVector(repeating: .zero, count: v.count)
+            var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+            var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+            var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+            var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+            var results6 = C6.TangentVector(repeating: .zero, count: v.count)
+            var results7 = C7.TangentVector(repeating: .zero, count: v.count)
+            var results8 = C8.TangentVector(repeating: .zero, count: v.count)
+            var results9 = C9.TangentVector(repeating: .zero, count: v.count)
+            var results10 = C10.TangentVector(repeating: .zero, count: v.count)
+            var results1Index = results1.startIndex
+            var results2Index = results2.startIndex
+            var results3Index = results3.startIndex
+            var results4Index = results4.startIndex
+            var results5Index = results5.startIndex
+            var results6Index = results6.startIndex
+            var results7Index = results7.startIndex
+            var results8Index = results8.startIndex
+            var results9Index = results9.startIndex
+            var results10Index = results10.startIndex
+
             for (tangentElement, pullback) in zip(v, pullbacks) {
                 let (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) = pullback(tangentElement)
-                results1.appendContribution(of: v1)
-                results2.appendContribution(of: v2)
-                results3.appendContribution(of: v3)
-                results4.appendContribution(of: v4)
-                results5.appendContribution(of: v5)
-                results6.appendContribution(of: v6)
-                results7.appendContribution(of: v7)
-                results8.appendContribution(of: v8)
-                results9.appendContribution(of: v9)
-                results10.appendContribution(of: v10)
+                results1.writeTangentContribution(of: v1, at: results1Index)
+                results2.writeTangentContribution(of: v2, at: results2Index)
+                results3.writeTangentContribution(of: v3, at: results3Index)
+                results4.writeTangentContribution(of: v4, at: results4Index)
+                results5.writeTangentContribution(of: v5, at: results5Index)
+                results6.writeTangentContribution(of: v6, at: results6Index)
+                results7.writeTangentContribution(of: v7, at: results7Index)
+                results8.writeTangentContribution(of: v8, at: results8Index)
+                results9.writeTangentContribution(of: v9, at: results9Index)
+                results10.writeTangentContribution(of: v10, at: results10Index)
+                results1.formIndex(after: &results1Index)
+                results2.formIndex(after: &results2Index)
+                results3.formIndex(after: &results3Index)
+                results4.formIndex(after: &results4Index)
+                results5.formIndex(after: &results5Index)
+                results6.formIndex(after: &results6Index)
+                results7.formIndex(after: &results7Index)
+                results8.formIndex(after: &results8Index)
+                results9.formIndex(after: &results9Index)
+                results10.formIndex(after: &results10Index)
             }
 
             return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWith+Arity11.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWith+Arity11.swift
@@ -282,41 +282,54 @@ public func _vjpDifferentiableZipWith<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C
         value: Array(results),
         pullback: { v in
             precondition(v.count == pullbacks.count)
-            var results1 = C1.TangentVector()
-            results1.reserveCapacity(v.count)
-            var results2 = C2.TangentVector()
-            results2.reserveCapacity(v.count)
-            var results3 = C3.TangentVector()
-            results3.reserveCapacity(v.count)
-            var results4 = C4.TangentVector()
-            results4.reserveCapacity(v.count)
-            var results5 = C5.TangentVector()
-            results5.reserveCapacity(v.count)
-            var results6 = C6.TangentVector()
-            results6.reserveCapacity(v.count)
-            var results7 = C7.TangentVector()
-            results7.reserveCapacity(v.count)
-            var results8 = C8.TangentVector()
-            results8.reserveCapacity(v.count)
-            var results9 = C9.TangentVector()
-            results9.reserveCapacity(v.count)
-            var results10 = C10.TangentVector()
-            results10.reserveCapacity(v.count)
-            var results11 = C11.TangentVector()
-            results11.reserveCapacity(v.count)
+
+            var results1 = C1.TangentVector(repeating: .zero, count: v.count)
+            var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+            var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+            var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+            var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+            var results6 = C6.TangentVector(repeating: .zero, count: v.count)
+            var results7 = C7.TangentVector(repeating: .zero, count: v.count)
+            var results8 = C8.TangentVector(repeating: .zero, count: v.count)
+            var results9 = C9.TangentVector(repeating: .zero, count: v.count)
+            var results10 = C10.TangentVector(repeating: .zero, count: v.count)
+            var results11 = C11.TangentVector(repeating: .zero, count: v.count)
+            var results1Index = results1.startIndex
+            var results2Index = results2.startIndex
+            var results3Index = results3.startIndex
+            var results4Index = results4.startIndex
+            var results5Index = results5.startIndex
+            var results6Index = results6.startIndex
+            var results7Index = results7.startIndex
+            var results8Index = results8.startIndex
+            var results9Index = results9.startIndex
+            var results10Index = results10.startIndex
+            var results11Index = results11.startIndex
+
             for (tangentElement, pullback) in zip(v, pullbacks) {
                 let (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) = pullback(tangentElement)
-                results1.appendContribution(of: v1)
-                results2.appendContribution(of: v2)
-                results3.appendContribution(of: v3)
-                results4.appendContribution(of: v4)
-                results5.appendContribution(of: v5)
-                results6.appendContribution(of: v6)
-                results7.appendContribution(of: v7)
-                results8.appendContribution(of: v8)
-                results9.appendContribution(of: v9)
-                results10.appendContribution(of: v10)
-                results11.appendContribution(of: v11)
+                results1.writeTangentContribution(of: v1, at: results1Index)
+                results2.writeTangentContribution(of: v2, at: results2Index)
+                results3.writeTangentContribution(of: v3, at: results3Index)
+                results4.writeTangentContribution(of: v4, at: results4Index)
+                results5.writeTangentContribution(of: v5, at: results5Index)
+                results6.writeTangentContribution(of: v6, at: results6Index)
+                results7.writeTangentContribution(of: v7, at: results7Index)
+                results8.writeTangentContribution(of: v8, at: results8Index)
+                results9.writeTangentContribution(of: v9, at: results9Index)
+                results10.writeTangentContribution(of: v10, at: results10Index)
+                results11.writeTangentContribution(of: v11, at: results11Index)
+                results1.formIndex(after: &results1Index)
+                results2.formIndex(after: &results2Index)
+                results3.formIndex(after: &results3Index)
+                results4.formIndex(after: &results4Index)
+                results5.formIndex(after: &results5Index)
+                results6.formIndex(after: &results6Index)
+                results7.formIndex(after: &results7Index)
+                results8.formIndex(after: &results8Index)
+                results9.formIndex(after: &results9Index)
+                results10.formIndex(after: &results10Index)
+                results11.formIndex(after: &results11Index)
             }
 
             return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWith+Arity12.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWith+Arity12.swift
@@ -301,44 +301,58 @@ public func _vjpDifferentiableZipWith<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C
         value: Array(results),
         pullback: { v in
             precondition(v.count == pullbacks.count)
-            var results1 = C1.TangentVector()
-            results1.reserveCapacity(v.count)
-            var results2 = C2.TangentVector()
-            results2.reserveCapacity(v.count)
-            var results3 = C3.TangentVector()
-            results3.reserveCapacity(v.count)
-            var results4 = C4.TangentVector()
-            results4.reserveCapacity(v.count)
-            var results5 = C5.TangentVector()
-            results5.reserveCapacity(v.count)
-            var results6 = C6.TangentVector()
-            results6.reserveCapacity(v.count)
-            var results7 = C7.TangentVector()
-            results7.reserveCapacity(v.count)
-            var results8 = C8.TangentVector()
-            results8.reserveCapacity(v.count)
-            var results9 = C9.TangentVector()
-            results9.reserveCapacity(v.count)
-            var results10 = C10.TangentVector()
-            results10.reserveCapacity(v.count)
-            var results11 = C11.TangentVector()
-            results11.reserveCapacity(v.count)
-            var results12 = C12.TangentVector()
-            results12.reserveCapacity(v.count)
+
+            var results1 = C1.TangentVector(repeating: .zero, count: v.count)
+            var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+            var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+            var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+            var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+            var results6 = C6.TangentVector(repeating: .zero, count: v.count)
+            var results7 = C7.TangentVector(repeating: .zero, count: v.count)
+            var results8 = C8.TangentVector(repeating: .zero, count: v.count)
+            var results9 = C9.TangentVector(repeating: .zero, count: v.count)
+            var results10 = C10.TangentVector(repeating: .zero, count: v.count)
+            var results11 = C11.TangentVector(repeating: .zero, count: v.count)
+            var results12 = C12.TangentVector(repeating: .zero, count: v.count)
+            var results1Index = results1.startIndex
+            var results2Index = results2.startIndex
+            var results3Index = results3.startIndex
+            var results4Index = results4.startIndex
+            var results5Index = results5.startIndex
+            var results6Index = results6.startIndex
+            var results7Index = results7.startIndex
+            var results8Index = results8.startIndex
+            var results9Index = results9.startIndex
+            var results10Index = results10.startIndex
+            var results11Index = results11.startIndex
+            var results12Index = results12.startIndex
+
             for (tangentElement, pullback) in zip(v, pullbacks) {
                 let (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) = pullback(tangentElement)
-                results1.appendContribution(of: v1)
-                results2.appendContribution(of: v2)
-                results3.appendContribution(of: v3)
-                results4.appendContribution(of: v4)
-                results5.appendContribution(of: v5)
-                results6.appendContribution(of: v6)
-                results7.appendContribution(of: v7)
-                results8.appendContribution(of: v8)
-                results9.appendContribution(of: v9)
-                results10.appendContribution(of: v10)
-                results11.appendContribution(of: v11)
-                results12.appendContribution(of: v12)
+                results1.writeTangentContribution(of: v1, at: results1Index)
+                results2.writeTangentContribution(of: v2, at: results2Index)
+                results3.writeTangentContribution(of: v3, at: results3Index)
+                results4.writeTangentContribution(of: v4, at: results4Index)
+                results5.writeTangentContribution(of: v5, at: results5Index)
+                results6.writeTangentContribution(of: v6, at: results6Index)
+                results7.writeTangentContribution(of: v7, at: results7Index)
+                results8.writeTangentContribution(of: v8, at: results8Index)
+                results9.writeTangentContribution(of: v9, at: results9Index)
+                results10.writeTangentContribution(of: v10, at: results10Index)
+                results11.writeTangentContribution(of: v11, at: results11Index)
+                results12.writeTangentContribution(of: v12, at: results12Index)
+                results1.formIndex(after: &results1Index)
+                results2.formIndex(after: &results2Index)
+                results3.formIndex(after: &results3Index)
+                results4.formIndex(after: &results4Index)
+                results5.formIndex(after: &results5Index)
+                results6.formIndex(after: &results6Index)
+                results7.formIndex(after: &results7Index)
+                results8.formIndex(after: &results8Index)
+                results9.formIndex(after: &results9Index)
+                results10.formIndex(after: &results10Index)
+                results11.formIndex(after: &results11Index)
+                results12.formIndex(after: &results12Index)
             }
 
             return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWith+Arity13.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWith+Arity13.swift
@@ -320,47 +320,62 @@ public func _vjpDifferentiableZipWith<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C
         value: Array(results),
         pullback: { v in
             precondition(v.count == pullbacks.count)
-            var results1 = C1.TangentVector()
-            results1.reserveCapacity(v.count)
-            var results2 = C2.TangentVector()
-            results2.reserveCapacity(v.count)
-            var results3 = C3.TangentVector()
-            results3.reserveCapacity(v.count)
-            var results4 = C4.TangentVector()
-            results4.reserveCapacity(v.count)
-            var results5 = C5.TangentVector()
-            results5.reserveCapacity(v.count)
-            var results6 = C6.TangentVector()
-            results6.reserveCapacity(v.count)
-            var results7 = C7.TangentVector()
-            results7.reserveCapacity(v.count)
-            var results8 = C8.TangentVector()
-            results8.reserveCapacity(v.count)
-            var results9 = C9.TangentVector()
-            results9.reserveCapacity(v.count)
-            var results10 = C10.TangentVector()
-            results10.reserveCapacity(v.count)
-            var results11 = C11.TangentVector()
-            results11.reserveCapacity(v.count)
-            var results12 = C12.TangentVector()
-            results12.reserveCapacity(v.count)
-            var results13 = C13.TangentVector()
-            results13.reserveCapacity(v.count)
+
+            var results1 = C1.TangentVector(repeating: .zero, count: v.count)
+            var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+            var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+            var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+            var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+            var results6 = C6.TangentVector(repeating: .zero, count: v.count)
+            var results7 = C7.TangentVector(repeating: .zero, count: v.count)
+            var results8 = C8.TangentVector(repeating: .zero, count: v.count)
+            var results9 = C9.TangentVector(repeating: .zero, count: v.count)
+            var results10 = C10.TangentVector(repeating: .zero, count: v.count)
+            var results11 = C11.TangentVector(repeating: .zero, count: v.count)
+            var results12 = C12.TangentVector(repeating: .zero, count: v.count)
+            var results13 = C13.TangentVector(repeating: .zero, count: v.count)
+            var results1Index = results1.startIndex
+            var results2Index = results2.startIndex
+            var results3Index = results3.startIndex
+            var results4Index = results4.startIndex
+            var results5Index = results5.startIndex
+            var results6Index = results6.startIndex
+            var results7Index = results7.startIndex
+            var results8Index = results8.startIndex
+            var results9Index = results9.startIndex
+            var results10Index = results10.startIndex
+            var results11Index = results11.startIndex
+            var results12Index = results12.startIndex
+            var results13Index = results13.startIndex
+
             for (tangentElement, pullback) in zip(v, pullbacks) {
                 let (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) = pullback(tangentElement)
-                results1.appendContribution(of: v1)
-                results2.appendContribution(of: v2)
-                results3.appendContribution(of: v3)
-                results4.appendContribution(of: v4)
-                results5.appendContribution(of: v5)
-                results6.appendContribution(of: v6)
-                results7.appendContribution(of: v7)
-                results8.appendContribution(of: v8)
-                results9.appendContribution(of: v9)
-                results10.appendContribution(of: v10)
-                results11.appendContribution(of: v11)
-                results12.appendContribution(of: v12)
-                results13.appendContribution(of: v13)
+                results1.writeTangentContribution(of: v1, at: results1Index)
+                results2.writeTangentContribution(of: v2, at: results2Index)
+                results3.writeTangentContribution(of: v3, at: results3Index)
+                results4.writeTangentContribution(of: v4, at: results4Index)
+                results5.writeTangentContribution(of: v5, at: results5Index)
+                results6.writeTangentContribution(of: v6, at: results6Index)
+                results7.writeTangentContribution(of: v7, at: results7Index)
+                results8.writeTangentContribution(of: v8, at: results8Index)
+                results9.writeTangentContribution(of: v9, at: results9Index)
+                results10.writeTangentContribution(of: v10, at: results10Index)
+                results11.writeTangentContribution(of: v11, at: results11Index)
+                results12.writeTangentContribution(of: v12, at: results12Index)
+                results13.writeTangentContribution(of: v13, at: results13Index)
+                results1.formIndex(after: &results1Index)
+                results2.formIndex(after: &results2Index)
+                results3.formIndex(after: &results3Index)
+                results4.formIndex(after: &results4Index)
+                results5.formIndex(after: &results5Index)
+                results6.formIndex(after: &results6Index)
+                results7.formIndex(after: &results7Index)
+                results8.formIndex(after: &results8Index)
+                results9.formIndex(after: &results9Index)
+                results10.formIndex(after: &results10Index)
+                results11.formIndex(after: &results11Index)
+                results12.formIndex(after: &results12Index)
+                results13.formIndex(after: &results13Index)
             }
 
             return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWith+Arity14.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWith+Arity14.swift
@@ -339,50 +339,66 @@ public func _vjpDifferentiableZipWith<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C
         value: Array(results),
         pullback: { v in
             precondition(v.count == pullbacks.count)
-            var results1 = C1.TangentVector()
-            results1.reserveCapacity(v.count)
-            var results2 = C2.TangentVector()
-            results2.reserveCapacity(v.count)
-            var results3 = C3.TangentVector()
-            results3.reserveCapacity(v.count)
-            var results4 = C4.TangentVector()
-            results4.reserveCapacity(v.count)
-            var results5 = C5.TangentVector()
-            results5.reserveCapacity(v.count)
-            var results6 = C6.TangentVector()
-            results6.reserveCapacity(v.count)
-            var results7 = C7.TangentVector()
-            results7.reserveCapacity(v.count)
-            var results8 = C8.TangentVector()
-            results8.reserveCapacity(v.count)
-            var results9 = C9.TangentVector()
-            results9.reserveCapacity(v.count)
-            var results10 = C10.TangentVector()
-            results10.reserveCapacity(v.count)
-            var results11 = C11.TangentVector()
-            results11.reserveCapacity(v.count)
-            var results12 = C12.TangentVector()
-            results12.reserveCapacity(v.count)
-            var results13 = C13.TangentVector()
-            results13.reserveCapacity(v.count)
-            var results14 = C14.TangentVector()
-            results14.reserveCapacity(v.count)
+
+            var results1 = C1.TangentVector(repeating: .zero, count: v.count)
+            var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+            var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+            var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+            var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+            var results6 = C6.TangentVector(repeating: .zero, count: v.count)
+            var results7 = C7.TangentVector(repeating: .zero, count: v.count)
+            var results8 = C8.TangentVector(repeating: .zero, count: v.count)
+            var results9 = C9.TangentVector(repeating: .zero, count: v.count)
+            var results10 = C10.TangentVector(repeating: .zero, count: v.count)
+            var results11 = C11.TangentVector(repeating: .zero, count: v.count)
+            var results12 = C12.TangentVector(repeating: .zero, count: v.count)
+            var results13 = C13.TangentVector(repeating: .zero, count: v.count)
+            var results14 = C14.TangentVector(repeating: .zero, count: v.count)
+            var results1Index = results1.startIndex
+            var results2Index = results2.startIndex
+            var results3Index = results3.startIndex
+            var results4Index = results4.startIndex
+            var results5Index = results5.startIndex
+            var results6Index = results6.startIndex
+            var results7Index = results7.startIndex
+            var results8Index = results8.startIndex
+            var results9Index = results9.startIndex
+            var results10Index = results10.startIndex
+            var results11Index = results11.startIndex
+            var results12Index = results12.startIndex
+            var results13Index = results13.startIndex
+            var results14Index = results14.startIndex
+
             for (tangentElement, pullback) in zip(v, pullbacks) {
                 let (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14) = pullback(tangentElement)
-                results1.appendContribution(of: v1)
-                results2.appendContribution(of: v2)
-                results3.appendContribution(of: v3)
-                results4.appendContribution(of: v4)
-                results5.appendContribution(of: v5)
-                results6.appendContribution(of: v6)
-                results7.appendContribution(of: v7)
-                results8.appendContribution(of: v8)
-                results9.appendContribution(of: v9)
-                results10.appendContribution(of: v10)
-                results11.appendContribution(of: v11)
-                results12.appendContribution(of: v12)
-                results13.appendContribution(of: v13)
-                results14.appendContribution(of: v14)
+                results1.writeTangentContribution(of: v1, at: results1Index)
+                results2.writeTangentContribution(of: v2, at: results2Index)
+                results3.writeTangentContribution(of: v3, at: results3Index)
+                results4.writeTangentContribution(of: v4, at: results4Index)
+                results5.writeTangentContribution(of: v5, at: results5Index)
+                results6.writeTangentContribution(of: v6, at: results6Index)
+                results7.writeTangentContribution(of: v7, at: results7Index)
+                results8.writeTangentContribution(of: v8, at: results8Index)
+                results9.writeTangentContribution(of: v9, at: results9Index)
+                results10.writeTangentContribution(of: v10, at: results10Index)
+                results11.writeTangentContribution(of: v11, at: results11Index)
+                results12.writeTangentContribution(of: v12, at: results12Index)
+                results13.writeTangentContribution(of: v13, at: results13Index)
+                results14.writeTangentContribution(of: v14, at: results14Index)
+                results1.formIndex(after: &results1Index)
+                results2.formIndex(after: &results2Index)
+                results3.formIndex(after: &results3Index)
+                results4.formIndex(after: &results4Index)
+                results5.formIndex(after: &results5Index)
+                results6.formIndex(after: &results6Index)
+                results7.formIndex(after: &results7Index)
+                results8.formIndex(after: &results8Index)
+                results9.formIndex(after: &results9Index)
+                results10.formIndex(after: &results10Index)
+                results11.formIndex(after: &results11Index)
+                results12.formIndex(after: &results12Index)
+                results13.formIndex(after: &results13Index)
+                results14.formIndex(after: &results14Index)
             }
 
             return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWith+Arity2.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWith+Arity2.swift
@@ -111,14 +111,18 @@ public func _vjpDifferentiableZipWith<C1, C2, Result>(
         value: Array(results),
         pullback: { v in
             precondition(v.count == pullbacks.count)
-            var results1 = C1.TangentVector()
-            results1.reserveCapacity(v.count)
-            var results2 = C2.TangentVector()
-            results2.reserveCapacity(v.count)
+
+            var results1 = C1.TangentVector(repeating: .zero, count: v.count)
+            var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+            var results1Index = results1.startIndex
+            var results2Index = results2.startIndex
+
             for (tangentElement, pullback) in zip(v, pullbacks) {
                 let (v1, v2) = pullback(tangentElement)
-                results1.appendContribution(of: v1)
-                results2.appendContribution(of: v2)
+                results1.writeTangentContribution(of: v1, at: results1Index)
+                results2.writeTangentContribution(of: v2, at: results2Index)
+                results1.formIndex(after: &results1Index)
+                results2.formIndex(after: &results2Index)
             }
 
             return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWith+Arity3.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWith+Arity3.swift
@@ -130,17 +130,22 @@ public func _vjpDifferentiableZipWith<C1, C2, C3, Result>(
         value: Array(results),
         pullback: { v in
             precondition(v.count == pullbacks.count)
-            var results1 = C1.TangentVector()
-            results1.reserveCapacity(v.count)
-            var results2 = C2.TangentVector()
-            results2.reserveCapacity(v.count)
-            var results3 = C3.TangentVector()
-            results3.reserveCapacity(v.count)
+
+            var results1 = C1.TangentVector(repeating: .zero, count: v.count)
+            var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+            var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+            var results1Index = results1.startIndex
+            var results2Index = results2.startIndex
+            var results3Index = results3.startIndex
+
             for (tangentElement, pullback) in zip(v, pullbacks) {
                 let (v1, v2, v3) = pullback(tangentElement)
-                results1.appendContribution(of: v1)
-                results2.appendContribution(of: v2)
-                results3.appendContribution(of: v3)
+                results1.writeTangentContribution(of: v1, at: results1Index)
+                results2.writeTangentContribution(of: v2, at: results2Index)
+                results3.writeTangentContribution(of: v3, at: results3Index)
+                results1.formIndex(after: &results1Index)
+                results2.formIndex(after: &results2Index)
+                results3.formIndex(after: &results3Index)
             }
 
             return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWith+Arity4.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWith+Arity4.swift
@@ -149,20 +149,26 @@ public func _vjpDifferentiableZipWith<C1, C2, C3, C4, Result>(
         value: Array(results),
         pullback: { v in
             precondition(v.count == pullbacks.count)
-            var results1 = C1.TangentVector()
-            results1.reserveCapacity(v.count)
-            var results2 = C2.TangentVector()
-            results2.reserveCapacity(v.count)
-            var results3 = C3.TangentVector()
-            results3.reserveCapacity(v.count)
-            var results4 = C4.TangentVector()
-            results4.reserveCapacity(v.count)
+
+            var results1 = C1.TangentVector(repeating: .zero, count: v.count)
+            var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+            var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+            var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+            var results1Index = results1.startIndex
+            var results2Index = results2.startIndex
+            var results3Index = results3.startIndex
+            var results4Index = results4.startIndex
+
             for (tangentElement, pullback) in zip(v, pullbacks) {
                 let (v1, v2, v3, v4) = pullback(tangentElement)
-                results1.appendContribution(of: v1)
-                results2.appendContribution(of: v2)
-                results3.appendContribution(of: v3)
-                results4.appendContribution(of: v4)
+                results1.writeTangentContribution(of: v1, at: results1Index)
+                results2.writeTangentContribution(of: v2, at: results2Index)
+                results3.writeTangentContribution(of: v3, at: results3Index)
+                results4.writeTangentContribution(of: v4, at: results4Index)
+                results1.formIndex(after: &results1Index)
+                results2.formIndex(after: &results2Index)
+                results3.formIndex(after: &results3Index)
+                results4.formIndex(after: &results4Index)
             }
 
             return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWith+Arity5.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWith+Arity5.swift
@@ -168,23 +168,30 @@ public func _vjpDifferentiableZipWith<C1, C2, C3, C4, C5, Result>(
         value: Array(results),
         pullback: { v in
             precondition(v.count == pullbacks.count)
-            var results1 = C1.TangentVector()
-            results1.reserveCapacity(v.count)
-            var results2 = C2.TangentVector()
-            results2.reserveCapacity(v.count)
-            var results3 = C3.TangentVector()
-            results3.reserveCapacity(v.count)
-            var results4 = C4.TangentVector()
-            results4.reserveCapacity(v.count)
-            var results5 = C5.TangentVector()
-            results5.reserveCapacity(v.count)
+
+            var results1 = C1.TangentVector(repeating: .zero, count: v.count)
+            var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+            var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+            var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+            var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+            var results1Index = results1.startIndex
+            var results2Index = results2.startIndex
+            var results3Index = results3.startIndex
+            var results4Index = results4.startIndex
+            var results5Index = results5.startIndex
+
             for (tangentElement, pullback) in zip(v, pullbacks) {
                 let (v1, v2, v3, v4, v5) = pullback(tangentElement)
-                results1.appendContribution(of: v1)
-                results2.appendContribution(of: v2)
-                results3.appendContribution(of: v3)
-                results4.appendContribution(of: v4)
-                results5.appendContribution(of: v5)
+                results1.writeTangentContribution(of: v1, at: results1Index)
+                results2.writeTangentContribution(of: v2, at: results2Index)
+                results3.writeTangentContribution(of: v3, at: results3Index)
+                results4.writeTangentContribution(of: v4, at: results4Index)
+                results5.writeTangentContribution(of: v5, at: results5Index)
+                results1.formIndex(after: &results1Index)
+                results2.formIndex(after: &results2Index)
+                results3.formIndex(after: &results3Index)
+                results4.formIndex(after: &results4Index)
+                results5.formIndex(after: &results5Index)
             }
 
             return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWith+Arity6.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWith+Arity6.swift
@@ -187,26 +187,34 @@ public func _vjpDifferentiableZipWith<C1, C2, C3, C4, C5, C6, Result>(
         value: Array(results),
         pullback: { v in
             precondition(v.count == pullbacks.count)
-            var results1 = C1.TangentVector()
-            results1.reserveCapacity(v.count)
-            var results2 = C2.TangentVector()
-            results2.reserveCapacity(v.count)
-            var results3 = C3.TangentVector()
-            results3.reserveCapacity(v.count)
-            var results4 = C4.TangentVector()
-            results4.reserveCapacity(v.count)
-            var results5 = C5.TangentVector()
-            results5.reserveCapacity(v.count)
-            var results6 = C6.TangentVector()
-            results6.reserveCapacity(v.count)
+
+            var results1 = C1.TangentVector(repeating: .zero, count: v.count)
+            var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+            var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+            var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+            var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+            var results6 = C6.TangentVector(repeating: .zero, count: v.count)
+            var results1Index = results1.startIndex
+            var results2Index = results2.startIndex
+            var results3Index = results3.startIndex
+            var results4Index = results4.startIndex
+            var results5Index = results5.startIndex
+            var results6Index = results6.startIndex
+
             for (tangentElement, pullback) in zip(v, pullbacks) {
                 let (v1, v2, v3, v4, v5, v6) = pullback(tangentElement)
-                results1.appendContribution(of: v1)
-                results2.appendContribution(of: v2)
-                results3.appendContribution(of: v3)
-                results4.appendContribution(of: v4)
-                results5.appendContribution(of: v5)
-                results6.appendContribution(of: v6)
+                results1.writeTangentContribution(of: v1, at: results1Index)
+                results2.writeTangentContribution(of: v2, at: results2Index)
+                results3.writeTangentContribution(of: v3, at: results3Index)
+                results4.writeTangentContribution(of: v4, at: results4Index)
+                results5.writeTangentContribution(of: v5, at: results5Index)
+                results6.writeTangentContribution(of: v6, at: results6Index)
+                results1.formIndex(after: &results1Index)
+                results2.formIndex(after: &results2Index)
+                results3.formIndex(after: &results3Index)
+                results4.formIndex(after: &results4Index)
+                results5.formIndex(after: &results5Index)
+                results6.formIndex(after: &results6Index)
             }
 
             return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWith+Arity7.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWith+Arity7.swift
@@ -206,29 +206,38 @@ public func _vjpDifferentiableZipWith<C1, C2, C3, C4, C5, C6, C7, Result>(
         value: Array(results),
         pullback: { v in
             precondition(v.count == pullbacks.count)
-            var results1 = C1.TangentVector()
-            results1.reserveCapacity(v.count)
-            var results2 = C2.TangentVector()
-            results2.reserveCapacity(v.count)
-            var results3 = C3.TangentVector()
-            results3.reserveCapacity(v.count)
-            var results4 = C4.TangentVector()
-            results4.reserveCapacity(v.count)
-            var results5 = C5.TangentVector()
-            results5.reserveCapacity(v.count)
-            var results6 = C6.TangentVector()
-            results6.reserveCapacity(v.count)
-            var results7 = C7.TangentVector()
-            results7.reserveCapacity(v.count)
+
+            var results1 = C1.TangentVector(repeating: .zero, count: v.count)
+            var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+            var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+            var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+            var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+            var results6 = C6.TangentVector(repeating: .zero, count: v.count)
+            var results7 = C7.TangentVector(repeating: .zero, count: v.count)
+            var results1Index = results1.startIndex
+            var results2Index = results2.startIndex
+            var results3Index = results3.startIndex
+            var results4Index = results4.startIndex
+            var results5Index = results5.startIndex
+            var results6Index = results6.startIndex
+            var results7Index = results7.startIndex
+
             for (tangentElement, pullback) in zip(v, pullbacks) {
                 let (v1, v2, v3, v4, v5, v6, v7) = pullback(tangentElement)
-                results1.appendContribution(of: v1)
-                results2.appendContribution(of: v2)
-                results3.appendContribution(of: v3)
-                results4.appendContribution(of: v4)
-                results5.appendContribution(of: v5)
-                results6.appendContribution(of: v6)
-                results7.appendContribution(of: v7)
+                results1.writeTangentContribution(of: v1, at: results1Index)
+                results2.writeTangentContribution(of: v2, at: results2Index)
+                results3.writeTangentContribution(of: v3, at: results3Index)
+                results4.writeTangentContribution(of: v4, at: results4Index)
+                results5.writeTangentContribution(of: v5, at: results5Index)
+                results6.writeTangentContribution(of: v6, at: results6Index)
+                results7.writeTangentContribution(of: v7, at: results7Index)
+                results1.formIndex(after: &results1Index)
+                results2.formIndex(after: &results2Index)
+                results3.formIndex(after: &results3Index)
+                results4.formIndex(after: &results4Index)
+                results5.formIndex(after: &results5Index)
+                results6.formIndex(after: &results6Index)
+                results7.formIndex(after: &results7Index)
             }
 
             return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWith+Arity8.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWith+Arity8.swift
@@ -225,32 +225,42 @@ public func _vjpDifferentiableZipWith<C1, C2, C3, C4, C5, C6, C7, C8, Result>(
         value: Array(results),
         pullback: { v in
             precondition(v.count == pullbacks.count)
-            var results1 = C1.TangentVector()
-            results1.reserveCapacity(v.count)
-            var results2 = C2.TangentVector()
-            results2.reserveCapacity(v.count)
-            var results3 = C3.TangentVector()
-            results3.reserveCapacity(v.count)
-            var results4 = C4.TangentVector()
-            results4.reserveCapacity(v.count)
-            var results5 = C5.TangentVector()
-            results5.reserveCapacity(v.count)
-            var results6 = C6.TangentVector()
-            results6.reserveCapacity(v.count)
-            var results7 = C7.TangentVector()
-            results7.reserveCapacity(v.count)
-            var results8 = C8.TangentVector()
-            results8.reserveCapacity(v.count)
+
+            var results1 = C1.TangentVector(repeating: .zero, count: v.count)
+            var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+            var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+            var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+            var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+            var results6 = C6.TangentVector(repeating: .zero, count: v.count)
+            var results7 = C7.TangentVector(repeating: .zero, count: v.count)
+            var results8 = C8.TangentVector(repeating: .zero, count: v.count)
+            var results1Index = results1.startIndex
+            var results2Index = results2.startIndex
+            var results3Index = results3.startIndex
+            var results4Index = results4.startIndex
+            var results5Index = results5.startIndex
+            var results6Index = results6.startIndex
+            var results7Index = results7.startIndex
+            var results8Index = results8.startIndex
+
             for (tangentElement, pullback) in zip(v, pullbacks) {
                 let (v1, v2, v3, v4, v5, v6, v7, v8) = pullback(tangentElement)
-                results1.appendContribution(of: v1)
-                results2.appendContribution(of: v2)
-                results3.appendContribution(of: v3)
-                results4.appendContribution(of: v4)
-                results5.appendContribution(of: v5)
-                results6.appendContribution(of: v6)
-                results7.appendContribution(of: v7)
-                results8.appendContribution(of: v8)
+                results1.writeTangentContribution(of: v1, at: results1Index)
+                results2.writeTangentContribution(of: v2, at: results2Index)
+                results3.writeTangentContribution(of: v3, at: results3Index)
+                results4.writeTangentContribution(of: v4, at: results4Index)
+                results5.writeTangentContribution(of: v5, at: results5Index)
+                results6.writeTangentContribution(of: v6, at: results6Index)
+                results7.writeTangentContribution(of: v7, at: results7Index)
+                results8.writeTangentContribution(of: v8, at: results8Index)
+                results1.formIndex(after: &results1Index)
+                results2.formIndex(after: &results2Index)
+                results3.formIndex(after: &results3Index)
+                results4.formIndex(after: &results4Index)
+                results5.formIndex(after: &results5Index)
+                results6.formIndex(after: &results6Index)
+                results7.formIndex(after: &results7Index)
+                results8.formIndex(after: &results8Index)
             }
 
             return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWith+Arity9.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWith+Arity9.swift
@@ -244,35 +244,46 @@ public func _vjpDifferentiableZipWith<C1, C2, C3, C4, C5, C6, C7, C8, C9, Result
         value: Array(results),
         pullback: { v in
             precondition(v.count == pullbacks.count)
-            var results1 = C1.TangentVector()
-            results1.reserveCapacity(v.count)
-            var results2 = C2.TangentVector()
-            results2.reserveCapacity(v.count)
-            var results3 = C3.TangentVector()
-            results3.reserveCapacity(v.count)
-            var results4 = C4.TangentVector()
-            results4.reserveCapacity(v.count)
-            var results5 = C5.TangentVector()
-            results5.reserveCapacity(v.count)
-            var results6 = C6.TangentVector()
-            results6.reserveCapacity(v.count)
-            var results7 = C7.TangentVector()
-            results7.reserveCapacity(v.count)
-            var results8 = C8.TangentVector()
-            results8.reserveCapacity(v.count)
-            var results9 = C9.TangentVector()
-            results9.reserveCapacity(v.count)
+
+            var results1 = C1.TangentVector(repeating: .zero, count: v.count)
+            var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+            var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+            var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+            var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+            var results6 = C6.TangentVector(repeating: .zero, count: v.count)
+            var results7 = C7.TangentVector(repeating: .zero, count: v.count)
+            var results8 = C8.TangentVector(repeating: .zero, count: v.count)
+            var results9 = C9.TangentVector(repeating: .zero, count: v.count)
+            var results1Index = results1.startIndex
+            var results2Index = results2.startIndex
+            var results3Index = results3.startIndex
+            var results4Index = results4.startIndex
+            var results5Index = results5.startIndex
+            var results6Index = results6.startIndex
+            var results7Index = results7.startIndex
+            var results8Index = results8.startIndex
+            var results9Index = results9.startIndex
+
             for (tangentElement, pullback) in zip(v, pullbacks) {
                 let (v1, v2, v3, v4, v5, v6, v7, v8, v9) = pullback(tangentElement)
-                results1.appendContribution(of: v1)
-                results2.appendContribution(of: v2)
-                results3.appendContribution(of: v3)
-                results4.appendContribution(of: v4)
-                results5.appendContribution(of: v5)
-                results6.appendContribution(of: v6)
-                results7.appendContribution(of: v7)
-                results8.appendContribution(of: v8)
-                results9.appendContribution(of: v9)
+                results1.writeTangentContribution(of: v1, at: results1Index)
+                results2.writeTangentContribution(of: v2, at: results2Index)
+                results3.writeTangentContribution(of: v3, at: results3Index)
+                results4.writeTangentContribution(of: v4, at: results4Index)
+                results5.writeTangentContribution(of: v5, at: results5Index)
+                results6.writeTangentContribution(of: v6, at: results6Index)
+                results7.writeTangentContribution(of: v7, at: results7Index)
+                results8.writeTangentContribution(of: v8, at: results8Index)
+                results9.writeTangentContribution(of: v9, at: results9Index)
+                results1.formIndex(after: &results1Index)
+                results2.formIndex(after: &results2Index)
+                results3.formIndex(after: &results3Index)
+                results4.formIndex(after: &results4Index)
+                results5.formIndex(after: &results5Index)
+                results6.formIndex(after: &results6Index)
+                results7.formIndex(after: &results7Index)
+                results8.formIndex(after: &results8Index)
+                results9.formIndex(after: &results9Index)
             }
 
             return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity10.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity10.swift
@@ -257,36 +257,47 @@ public func _vjpDifferentiableZipWith<Inout, C2, C3, C4, C5, C6, C7, C8, C9, C10
         value: (),
         pullback: { v in
             precondition(v.count == pullbacks.count)
-            var results2 = C2.TangentVector()
-            results2.reserveCapacity(v.count)
-            var results3 = C3.TangentVector()
-            results3.reserveCapacity(v.count)
-            var results4 = C4.TangentVector()
-            results4.reserveCapacity(v.count)
-            var results5 = C5.TangentVector()
-            results5.reserveCapacity(v.count)
-            var results6 = C6.TangentVector()
-            results6.reserveCapacity(v.count)
-            var results7 = C7.TangentVector()
-            results7.reserveCapacity(v.count)
-            var results8 = C8.TangentVector()
-            results8.reserveCapacity(v.count)
-            var results9 = C9.TangentVector()
-            results9.reserveCapacity(v.count)
-            var results10 = C10.TangentVector()
-            results10.reserveCapacity(v.count)
+
+            var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+            var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+            var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+            var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+            var results6 = C6.TangentVector(repeating: .zero, count: v.count)
+            var results7 = C7.TangentVector(repeating: .zero, count: v.count)
+            var results8 = C8.TangentVector(repeating: .zero, count: v.count)
+            var results9 = C9.TangentVector(repeating: .zero, count: v.count)
+            var results10 = C10.TangentVector(repeating: .zero, count: v.count)
+            var results2Index = results2.startIndex
+            var results3Index = results3.startIndex
+            var results4Index = results4.startIndex
+            var results5Index = results5.startIndex
+            var results6Index = results6.startIndex
+            var results7Index = results7.startIndex
+            var results8Index = results8.startIndex
+            var results9Index = results9.startIndex
+            var results10Index = results10.startIndex
+
             for (index, (tangentElement, pullback)) in zip(v.indices, zip(v, pullbacks)) {
                 let (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10) = pullback(tangentElement)
                 v[index] = v1
-                results2.appendContribution(of: v2)
-                results3.appendContribution(of: v3)
-                results4.appendContribution(of: v4)
-                results5.appendContribution(of: v5)
-                results6.appendContribution(of: v6)
-                results7.appendContribution(of: v7)
-                results8.appendContribution(of: v8)
-                results9.appendContribution(of: v9)
-                results10.appendContribution(of: v10)
+                results2.writeTangentContribution(of: v2, at: results2Index)
+                results3.writeTangentContribution(of: v3, at: results3Index)
+                results4.writeTangentContribution(of: v4, at: results4Index)
+                results5.writeTangentContribution(of: v5, at: results5Index)
+                results6.writeTangentContribution(of: v6, at: results6Index)
+                results7.writeTangentContribution(of: v7, at: results7Index)
+                results8.writeTangentContribution(of: v8, at: results8Index)
+                results9.writeTangentContribution(of: v9, at: results9Index)
+                results10.writeTangentContribution(of: v10, at: results10Index)
+                results2.formIndex(after: &results2Index)
+                results3.formIndex(after: &results3Index)
+                results4.formIndex(after: &results4Index)
+                results5.formIndex(after: &results5Index)
+                results6.formIndex(after: &results6Index)
+                results7.formIndex(after: &results7Index)
+                results8.formIndex(after: &results8Index)
+                results9.formIndex(after: &results9Index)
+                results10.formIndex(after: &results10Index)
             }
 
             // swiftformat:disable:next redundantParens

--- a/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity11.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity11.swift
@@ -276,39 +276,51 @@ public func _vjpDifferentiableZipWith<Inout, C2, C3, C4, C5, C6, C7, C8, C9, C10
         value: (),
         pullback: { v in
             precondition(v.count == pullbacks.count)
-            var results2 = C2.TangentVector()
-            results2.reserveCapacity(v.count)
-            var results3 = C3.TangentVector()
-            results3.reserveCapacity(v.count)
-            var results4 = C4.TangentVector()
-            results4.reserveCapacity(v.count)
-            var results5 = C5.TangentVector()
-            results5.reserveCapacity(v.count)
-            var results6 = C6.TangentVector()
-            results6.reserveCapacity(v.count)
-            var results7 = C7.TangentVector()
-            results7.reserveCapacity(v.count)
-            var results8 = C8.TangentVector()
-            results8.reserveCapacity(v.count)
-            var results9 = C9.TangentVector()
-            results9.reserveCapacity(v.count)
-            var results10 = C10.TangentVector()
-            results10.reserveCapacity(v.count)
-            var results11 = C11.TangentVector()
-            results11.reserveCapacity(v.count)
+
+            var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+            var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+            var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+            var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+            var results6 = C6.TangentVector(repeating: .zero, count: v.count)
+            var results7 = C7.TangentVector(repeating: .zero, count: v.count)
+            var results8 = C8.TangentVector(repeating: .zero, count: v.count)
+            var results9 = C9.TangentVector(repeating: .zero, count: v.count)
+            var results10 = C10.TangentVector(repeating: .zero, count: v.count)
+            var results11 = C11.TangentVector(repeating: .zero, count: v.count)
+            var results2Index = results2.startIndex
+            var results3Index = results3.startIndex
+            var results4Index = results4.startIndex
+            var results5Index = results5.startIndex
+            var results6Index = results6.startIndex
+            var results7Index = results7.startIndex
+            var results8Index = results8.startIndex
+            var results9Index = results9.startIndex
+            var results10Index = results10.startIndex
+            var results11Index = results11.startIndex
+
             for (index, (tangentElement, pullback)) in zip(v.indices, zip(v, pullbacks)) {
                 let (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11) = pullback(tangentElement)
                 v[index] = v1
-                results2.appendContribution(of: v2)
-                results3.appendContribution(of: v3)
-                results4.appendContribution(of: v4)
-                results5.appendContribution(of: v5)
-                results6.appendContribution(of: v6)
-                results7.appendContribution(of: v7)
-                results8.appendContribution(of: v8)
-                results9.appendContribution(of: v9)
-                results10.appendContribution(of: v10)
-                results11.appendContribution(of: v11)
+                results2.writeTangentContribution(of: v2, at: results2Index)
+                results3.writeTangentContribution(of: v3, at: results3Index)
+                results4.writeTangentContribution(of: v4, at: results4Index)
+                results5.writeTangentContribution(of: v5, at: results5Index)
+                results6.writeTangentContribution(of: v6, at: results6Index)
+                results7.writeTangentContribution(of: v7, at: results7Index)
+                results8.writeTangentContribution(of: v8, at: results8Index)
+                results9.writeTangentContribution(of: v9, at: results9Index)
+                results10.writeTangentContribution(of: v10, at: results10Index)
+                results11.writeTangentContribution(of: v11, at: results11Index)
+                results2.formIndex(after: &results2Index)
+                results3.formIndex(after: &results3Index)
+                results4.formIndex(after: &results4Index)
+                results5.formIndex(after: &results5Index)
+                results6.formIndex(after: &results6Index)
+                results7.formIndex(after: &results7Index)
+                results8.formIndex(after: &results8Index)
+                results9.formIndex(after: &results9Index)
+                results10.formIndex(after: &results10Index)
+                results11.formIndex(after: &results11Index)
             }
 
             // swiftformat:disable:next redundantParens

--- a/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity12.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity12.swift
@@ -295,42 +295,55 @@ public func _vjpDifferentiableZipWith<Inout, C2, C3, C4, C5, C6, C7, C8, C9, C10
         value: (),
         pullback: { v in
             precondition(v.count == pullbacks.count)
-            var results2 = C2.TangentVector()
-            results2.reserveCapacity(v.count)
-            var results3 = C3.TangentVector()
-            results3.reserveCapacity(v.count)
-            var results4 = C4.TangentVector()
-            results4.reserveCapacity(v.count)
-            var results5 = C5.TangentVector()
-            results5.reserveCapacity(v.count)
-            var results6 = C6.TangentVector()
-            results6.reserveCapacity(v.count)
-            var results7 = C7.TangentVector()
-            results7.reserveCapacity(v.count)
-            var results8 = C8.TangentVector()
-            results8.reserveCapacity(v.count)
-            var results9 = C9.TangentVector()
-            results9.reserveCapacity(v.count)
-            var results10 = C10.TangentVector()
-            results10.reserveCapacity(v.count)
-            var results11 = C11.TangentVector()
-            results11.reserveCapacity(v.count)
-            var results12 = C12.TangentVector()
-            results12.reserveCapacity(v.count)
+
+            var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+            var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+            var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+            var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+            var results6 = C6.TangentVector(repeating: .zero, count: v.count)
+            var results7 = C7.TangentVector(repeating: .zero, count: v.count)
+            var results8 = C8.TangentVector(repeating: .zero, count: v.count)
+            var results9 = C9.TangentVector(repeating: .zero, count: v.count)
+            var results10 = C10.TangentVector(repeating: .zero, count: v.count)
+            var results11 = C11.TangentVector(repeating: .zero, count: v.count)
+            var results12 = C12.TangentVector(repeating: .zero, count: v.count)
+            var results2Index = results2.startIndex
+            var results3Index = results3.startIndex
+            var results4Index = results4.startIndex
+            var results5Index = results5.startIndex
+            var results6Index = results6.startIndex
+            var results7Index = results7.startIndex
+            var results8Index = results8.startIndex
+            var results9Index = results9.startIndex
+            var results10Index = results10.startIndex
+            var results11Index = results11.startIndex
+            var results12Index = results12.startIndex
+
             for (index, (tangentElement, pullback)) in zip(v.indices, zip(v, pullbacks)) {
                 let (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12) = pullback(tangentElement)
                 v[index] = v1
-                results2.appendContribution(of: v2)
-                results3.appendContribution(of: v3)
-                results4.appendContribution(of: v4)
-                results5.appendContribution(of: v5)
-                results6.appendContribution(of: v6)
-                results7.appendContribution(of: v7)
-                results8.appendContribution(of: v8)
-                results9.appendContribution(of: v9)
-                results10.appendContribution(of: v10)
-                results11.appendContribution(of: v11)
-                results12.appendContribution(of: v12)
+                results2.writeTangentContribution(of: v2, at: results2Index)
+                results3.writeTangentContribution(of: v3, at: results3Index)
+                results4.writeTangentContribution(of: v4, at: results4Index)
+                results5.writeTangentContribution(of: v5, at: results5Index)
+                results6.writeTangentContribution(of: v6, at: results6Index)
+                results7.writeTangentContribution(of: v7, at: results7Index)
+                results8.writeTangentContribution(of: v8, at: results8Index)
+                results9.writeTangentContribution(of: v9, at: results9Index)
+                results10.writeTangentContribution(of: v10, at: results10Index)
+                results11.writeTangentContribution(of: v11, at: results11Index)
+                results12.writeTangentContribution(of: v12, at: results12Index)
+                results2.formIndex(after: &results2Index)
+                results3.formIndex(after: &results3Index)
+                results4.formIndex(after: &results4Index)
+                results5.formIndex(after: &results5Index)
+                results6.formIndex(after: &results6Index)
+                results7.formIndex(after: &results7Index)
+                results8.formIndex(after: &results8Index)
+                results9.formIndex(after: &results9Index)
+                results10.formIndex(after: &results10Index)
+                results11.formIndex(after: &results11Index)
+                results12.formIndex(after: &results12Index)
             }
 
             // swiftformat:disable:next redundantParens

--- a/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity13.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity13.swift
@@ -314,45 +314,59 @@ public func _vjpDifferentiableZipWith<Inout, C2, C3, C4, C5, C6, C7, C8, C9, C10
         value: (),
         pullback: { v in
             precondition(v.count == pullbacks.count)
-            var results2 = C2.TangentVector()
-            results2.reserveCapacity(v.count)
-            var results3 = C3.TangentVector()
-            results3.reserveCapacity(v.count)
-            var results4 = C4.TangentVector()
-            results4.reserveCapacity(v.count)
-            var results5 = C5.TangentVector()
-            results5.reserveCapacity(v.count)
-            var results6 = C6.TangentVector()
-            results6.reserveCapacity(v.count)
-            var results7 = C7.TangentVector()
-            results7.reserveCapacity(v.count)
-            var results8 = C8.TangentVector()
-            results8.reserveCapacity(v.count)
-            var results9 = C9.TangentVector()
-            results9.reserveCapacity(v.count)
-            var results10 = C10.TangentVector()
-            results10.reserveCapacity(v.count)
-            var results11 = C11.TangentVector()
-            results11.reserveCapacity(v.count)
-            var results12 = C12.TangentVector()
-            results12.reserveCapacity(v.count)
-            var results13 = C13.TangentVector()
-            results13.reserveCapacity(v.count)
+
+            var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+            var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+            var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+            var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+            var results6 = C6.TangentVector(repeating: .zero, count: v.count)
+            var results7 = C7.TangentVector(repeating: .zero, count: v.count)
+            var results8 = C8.TangentVector(repeating: .zero, count: v.count)
+            var results9 = C9.TangentVector(repeating: .zero, count: v.count)
+            var results10 = C10.TangentVector(repeating: .zero, count: v.count)
+            var results11 = C11.TangentVector(repeating: .zero, count: v.count)
+            var results12 = C12.TangentVector(repeating: .zero, count: v.count)
+            var results13 = C13.TangentVector(repeating: .zero, count: v.count)
+            var results2Index = results2.startIndex
+            var results3Index = results3.startIndex
+            var results4Index = results4.startIndex
+            var results5Index = results5.startIndex
+            var results6Index = results6.startIndex
+            var results7Index = results7.startIndex
+            var results8Index = results8.startIndex
+            var results9Index = results9.startIndex
+            var results10Index = results10.startIndex
+            var results11Index = results11.startIndex
+            var results12Index = results12.startIndex
+            var results13Index = results13.startIndex
+
             for (index, (tangentElement, pullback)) in zip(v.indices, zip(v, pullbacks)) {
                 let (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13) = pullback(tangentElement)
                 v[index] = v1
-                results2.appendContribution(of: v2)
-                results3.appendContribution(of: v3)
-                results4.appendContribution(of: v4)
-                results5.appendContribution(of: v5)
-                results6.appendContribution(of: v6)
-                results7.appendContribution(of: v7)
-                results8.appendContribution(of: v8)
-                results9.appendContribution(of: v9)
-                results10.appendContribution(of: v10)
-                results11.appendContribution(of: v11)
-                results12.appendContribution(of: v12)
-                results13.appendContribution(of: v13)
+                results2.writeTangentContribution(of: v2, at: results2Index)
+                results3.writeTangentContribution(of: v3, at: results3Index)
+                results4.writeTangentContribution(of: v4, at: results4Index)
+                results5.writeTangentContribution(of: v5, at: results5Index)
+                results6.writeTangentContribution(of: v6, at: results6Index)
+                results7.writeTangentContribution(of: v7, at: results7Index)
+                results8.writeTangentContribution(of: v8, at: results8Index)
+                results9.writeTangentContribution(of: v9, at: results9Index)
+                results10.writeTangentContribution(of: v10, at: results10Index)
+                results11.writeTangentContribution(of: v11, at: results11Index)
+                results12.writeTangentContribution(of: v12, at: results12Index)
+                results13.writeTangentContribution(of: v13, at: results13Index)
+                results2.formIndex(after: &results2Index)
+                results3.formIndex(after: &results3Index)
+                results4.formIndex(after: &results4Index)
+                results5.formIndex(after: &results5Index)
+                results6.formIndex(after: &results6Index)
+                results7.formIndex(after: &results7Index)
+                results8.formIndex(after: &results8Index)
+                results9.formIndex(after: &results9Index)
+                results10.formIndex(after: &results10Index)
+                results11.formIndex(after: &results11Index)
+                results12.formIndex(after: &results12Index)
+                results13.formIndex(after: &results13Index)
             }
 
             // swiftformat:disable:next redundantParens

--- a/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity14.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity14.swift
@@ -333,48 +333,63 @@ public func _vjpDifferentiableZipWith<Inout, C2, C3, C4, C5, C6, C7, C8, C9, C10
         value: (),
         pullback: { v in
             precondition(v.count == pullbacks.count)
-            var results2 = C2.TangentVector()
-            results2.reserveCapacity(v.count)
-            var results3 = C3.TangentVector()
-            results3.reserveCapacity(v.count)
-            var results4 = C4.TangentVector()
-            results4.reserveCapacity(v.count)
-            var results5 = C5.TangentVector()
-            results5.reserveCapacity(v.count)
-            var results6 = C6.TangentVector()
-            results6.reserveCapacity(v.count)
-            var results7 = C7.TangentVector()
-            results7.reserveCapacity(v.count)
-            var results8 = C8.TangentVector()
-            results8.reserveCapacity(v.count)
-            var results9 = C9.TangentVector()
-            results9.reserveCapacity(v.count)
-            var results10 = C10.TangentVector()
-            results10.reserveCapacity(v.count)
-            var results11 = C11.TangentVector()
-            results11.reserveCapacity(v.count)
-            var results12 = C12.TangentVector()
-            results12.reserveCapacity(v.count)
-            var results13 = C13.TangentVector()
-            results13.reserveCapacity(v.count)
-            var results14 = C14.TangentVector()
-            results14.reserveCapacity(v.count)
+
+            var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+            var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+            var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+            var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+            var results6 = C6.TangentVector(repeating: .zero, count: v.count)
+            var results7 = C7.TangentVector(repeating: .zero, count: v.count)
+            var results8 = C8.TangentVector(repeating: .zero, count: v.count)
+            var results9 = C9.TangentVector(repeating: .zero, count: v.count)
+            var results10 = C10.TangentVector(repeating: .zero, count: v.count)
+            var results11 = C11.TangentVector(repeating: .zero, count: v.count)
+            var results12 = C12.TangentVector(repeating: .zero, count: v.count)
+            var results13 = C13.TangentVector(repeating: .zero, count: v.count)
+            var results14 = C14.TangentVector(repeating: .zero, count: v.count)
+            var results2Index = results2.startIndex
+            var results3Index = results3.startIndex
+            var results4Index = results4.startIndex
+            var results5Index = results5.startIndex
+            var results6Index = results6.startIndex
+            var results7Index = results7.startIndex
+            var results8Index = results8.startIndex
+            var results9Index = results9.startIndex
+            var results10Index = results10.startIndex
+            var results11Index = results11.startIndex
+            var results12Index = results12.startIndex
+            var results13Index = results13.startIndex
+            var results14Index = results14.startIndex
+
             for (index, (tangentElement, pullback)) in zip(v.indices, zip(v, pullbacks)) {
                 let (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14) = pullback(tangentElement)
                 v[index] = v1
-                results2.appendContribution(of: v2)
-                results3.appendContribution(of: v3)
-                results4.appendContribution(of: v4)
-                results5.appendContribution(of: v5)
-                results6.appendContribution(of: v6)
-                results7.appendContribution(of: v7)
-                results8.appendContribution(of: v8)
-                results9.appendContribution(of: v9)
-                results10.appendContribution(of: v10)
-                results11.appendContribution(of: v11)
-                results12.appendContribution(of: v12)
-                results13.appendContribution(of: v13)
-                results14.appendContribution(of: v14)
+                results2.writeTangentContribution(of: v2, at: results2Index)
+                results3.writeTangentContribution(of: v3, at: results3Index)
+                results4.writeTangentContribution(of: v4, at: results4Index)
+                results5.writeTangentContribution(of: v5, at: results5Index)
+                results6.writeTangentContribution(of: v6, at: results6Index)
+                results7.writeTangentContribution(of: v7, at: results7Index)
+                results8.writeTangentContribution(of: v8, at: results8Index)
+                results9.writeTangentContribution(of: v9, at: results9Index)
+                results10.writeTangentContribution(of: v10, at: results10Index)
+                results11.writeTangentContribution(of: v11, at: results11Index)
+                results12.writeTangentContribution(of: v12, at: results12Index)
+                results13.writeTangentContribution(of: v13, at: results13Index)
+                results14.writeTangentContribution(of: v14, at: results14Index)
+                results2.formIndex(after: &results2Index)
+                results3.formIndex(after: &results3Index)
+                results4.formIndex(after: &results4Index)
+                results5.formIndex(after: &results5Index)
+                results6.formIndex(after: &results6Index)
+                results7.formIndex(after: &results7Index)
+                results8.formIndex(after: &results8Index)
+                results9.formIndex(after: &results9Index)
+                results10.formIndex(after: &results10Index)
+                results11.formIndex(after: &results11Index)
+                results12.formIndex(after: &results12Index)
+                results13.formIndex(after: &results13Index)
+                results14.formIndex(after: &results14Index)
             }
 
             // swiftformat:disable:next redundantParens

--- a/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity2.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity2.swift
@@ -105,12 +105,15 @@ public func _vjpDifferentiableZipWith<Inout, C2>(
         value: (),
         pullback: { v in
             precondition(v.count == pullbacks.count)
-            var results2 = C2.TangentVector()
-            results2.reserveCapacity(v.count)
+
+            var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+            var results2Index = results2.startIndex
+
             for (index, (tangentElement, pullback)) in zip(v.indices, zip(v, pullbacks)) {
                 let (v1, v2) = pullback(tangentElement)
                 v[index] = v1
-                results2.appendContribution(of: v2)
+                results2.writeTangentContribution(of: v2, at: results2Index)
+                results2.formIndex(after: &results2Index)
             }
 
             // swiftformat:disable:next redundantParens

--- a/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity3.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity3.swift
@@ -124,15 +124,19 @@ public func _vjpDifferentiableZipWith<Inout, C2, C3>(
         value: (),
         pullback: { v in
             precondition(v.count == pullbacks.count)
-            var results2 = C2.TangentVector()
-            results2.reserveCapacity(v.count)
-            var results3 = C3.TangentVector()
-            results3.reserveCapacity(v.count)
+
+            var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+            var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+            var results2Index = results2.startIndex
+            var results3Index = results3.startIndex
+
             for (index, (tangentElement, pullback)) in zip(v.indices, zip(v, pullbacks)) {
                 let (v1, v2, v3) = pullback(tangentElement)
                 v[index] = v1
-                results2.appendContribution(of: v2)
-                results3.appendContribution(of: v3)
+                results2.writeTangentContribution(of: v2, at: results2Index)
+                results3.writeTangentContribution(of: v3, at: results3Index)
+                results2.formIndex(after: &results2Index)
+                results3.formIndex(after: &results3Index)
             }
 
             // swiftformat:disable:next redundantParens

--- a/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity4.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity4.swift
@@ -143,18 +143,23 @@ public func _vjpDifferentiableZipWith<Inout, C2, C3, C4>(
         value: (),
         pullback: { v in
             precondition(v.count == pullbacks.count)
-            var results2 = C2.TangentVector()
-            results2.reserveCapacity(v.count)
-            var results3 = C3.TangentVector()
-            results3.reserveCapacity(v.count)
-            var results4 = C4.TangentVector()
-            results4.reserveCapacity(v.count)
+
+            var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+            var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+            var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+            var results2Index = results2.startIndex
+            var results3Index = results3.startIndex
+            var results4Index = results4.startIndex
+
             for (index, (tangentElement, pullback)) in zip(v.indices, zip(v, pullbacks)) {
                 let (v1, v2, v3, v4) = pullback(tangentElement)
                 v[index] = v1
-                results2.appendContribution(of: v2)
-                results3.appendContribution(of: v3)
-                results4.appendContribution(of: v4)
+                results2.writeTangentContribution(of: v2, at: results2Index)
+                results3.writeTangentContribution(of: v3, at: results3Index)
+                results4.writeTangentContribution(of: v4, at: results4Index)
+                results2.formIndex(after: &results2Index)
+                results3.formIndex(after: &results3Index)
+                results4.formIndex(after: &results4Index)
             }
 
             // swiftformat:disable:next redundantParens

--- a/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity5.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity5.swift
@@ -162,21 +162,27 @@ public func _vjpDifferentiableZipWith<Inout, C2, C3, C4, C5>(
         value: (),
         pullback: { v in
             precondition(v.count == pullbacks.count)
-            var results2 = C2.TangentVector()
-            results2.reserveCapacity(v.count)
-            var results3 = C3.TangentVector()
-            results3.reserveCapacity(v.count)
-            var results4 = C4.TangentVector()
-            results4.reserveCapacity(v.count)
-            var results5 = C5.TangentVector()
-            results5.reserveCapacity(v.count)
+
+            var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+            var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+            var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+            var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+            var results2Index = results2.startIndex
+            var results3Index = results3.startIndex
+            var results4Index = results4.startIndex
+            var results5Index = results5.startIndex
+
             for (index, (tangentElement, pullback)) in zip(v.indices, zip(v, pullbacks)) {
                 let (v1, v2, v3, v4, v5) = pullback(tangentElement)
                 v[index] = v1
-                results2.appendContribution(of: v2)
-                results3.appendContribution(of: v3)
-                results4.appendContribution(of: v4)
-                results5.appendContribution(of: v5)
+                results2.writeTangentContribution(of: v2, at: results2Index)
+                results3.writeTangentContribution(of: v3, at: results3Index)
+                results4.writeTangentContribution(of: v4, at: results4Index)
+                results5.writeTangentContribution(of: v5, at: results5Index)
+                results2.formIndex(after: &results2Index)
+                results3.formIndex(after: &results3Index)
+                results4.formIndex(after: &results4Index)
+                results5.formIndex(after: &results5Index)
             }
 
             // swiftformat:disable:next redundantParens

--- a/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity6.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity6.swift
@@ -181,24 +181,31 @@ public func _vjpDifferentiableZipWith<Inout, C2, C3, C4, C5, C6>(
         value: (),
         pullback: { v in
             precondition(v.count == pullbacks.count)
-            var results2 = C2.TangentVector()
-            results2.reserveCapacity(v.count)
-            var results3 = C3.TangentVector()
-            results3.reserveCapacity(v.count)
-            var results4 = C4.TangentVector()
-            results4.reserveCapacity(v.count)
-            var results5 = C5.TangentVector()
-            results5.reserveCapacity(v.count)
-            var results6 = C6.TangentVector()
-            results6.reserveCapacity(v.count)
+
+            var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+            var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+            var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+            var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+            var results6 = C6.TangentVector(repeating: .zero, count: v.count)
+            var results2Index = results2.startIndex
+            var results3Index = results3.startIndex
+            var results4Index = results4.startIndex
+            var results5Index = results5.startIndex
+            var results6Index = results6.startIndex
+
             for (index, (tangentElement, pullback)) in zip(v.indices, zip(v, pullbacks)) {
                 let (v1, v2, v3, v4, v5, v6) = pullback(tangentElement)
                 v[index] = v1
-                results2.appendContribution(of: v2)
-                results3.appendContribution(of: v3)
-                results4.appendContribution(of: v4)
-                results5.appendContribution(of: v5)
-                results6.appendContribution(of: v6)
+                results2.writeTangentContribution(of: v2, at: results2Index)
+                results3.writeTangentContribution(of: v3, at: results3Index)
+                results4.writeTangentContribution(of: v4, at: results4Index)
+                results5.writeTangentContribution(of: v5, at: results5Index)
+                results6.writeTangentContribution(of: v6, at: results6Index)
+                results2.formIndex(after: &results2Index)
+                results3.formIndex(after: &results3Index)
+                results4.formIndex(after: &results4Index)
+                results5.formIndex(after: &results5Index)
+                results6.formIndex(after: &results6Index)
             }
 
             // swiftformat:disable:next redundantParens

--- a/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity7.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity7.swift
@@ -200,27 +200,35 @@ public func _vjpDifferentiableZipWith<Inout, C2, C3, C4, C5, C6, C7>(
         value: (),
         pullback: { v in
             precondition(v.count == pullbacks.count)
-            var results2 = C2.TangentVector()
-            results2.reserveCapacity(v.count)
-            var results3 = C3.TangentVector()
-            results3.reserveCapacity(v.count)
-            var results4 = C4.TangentVector()
-            results4.reserveCapacity(v.count)
-            var results5 = C5.TangentVector()
-            results5.reserveCapacity(v.count)
-            var results6 = C6.TangentVector()
-            results6.reserveCapacity(v.count)
-            var results7 = C7.TangentVector()
-            results7.reserveCapacity(v.count)
+
+            var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+            var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+            var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+            var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+            var results6 = C6.TangentVector(repeating: .zero, count: v.count)
+            var results7 = C7.TangentVector(repeating: .zero, count: v.count)
+            var results2Index = results2.startIndex
+            var results3Index = results3.startIndex
+            var results4Index = results4.startIndex
+            var results5Index = results5.startIndex
+            var results6Index = results6.startIndex
+            var results7Index = results7.startIndex
+
             for (index, (tangentElement, pullback)) in zip(v.indices, zip(v, pullbacks)) {
                 let (v1, v2, v3, v4, v5, v6, v7) = pullback(tangentElement)
                 v[index] = v1
-                results2.appendContribution(of: v2)
-                results3.appendContribution(of: v3)
-                results4.appendContribution(of: v4)
-                results5.appendContribution(of: v5)
-                results6.appendContribution(of: v6)
-                results7.appendContribution(of: v7)
+                results2.writeTangentContribution(of: v2, at: results2Index)
+                results3.writeTangentContribution(of: v3, at: results3Index)
+                results4.writeTangentContribution(of: v4, at: results4Index)
+                results5.writeTangentContribution(of: v5, at: results5Index)
+                results6.writeTangentContribution(of: v6, at: results6Index)
+                results7.writeTangentContribution(of: v7, at: results7Index)
+                results2.formIndex(after: &results2Index)
+                results3.formIndex(after: &results3Index)
+                results4.formIndex(after: &results4Index)
+                results5.formIndex(after: &results5Index)
+                results6.formIndex(after: &results6Index)
+                results7.formIndex(after: &results7Index)
             }
 
             // swiftformat:disable:next redundantParens

--- a/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity8.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity8.swift
@@ -219,30 +219,39 @@ public func _vjpDifferentiableZipWith<Inout, C2, C3, C4, C5, C6, C7, C8>(
         value: (),
         pullback: { v in
             precondition(v.count == pullbacks.count)
-            var results2 = C2.TangentVector()
-            results2.reserveCapacity(v.count)
-            var results3 = C3.TangentVector()
-            results3.reserveCapacity(v.count)
-            var results4 = C4.TangentVector()
-            results4.reserveCapacity(v.count)
-            var results5 = C5.TangentVector()
-            results5.reserveCapacity(v.count)
-            var results6 = C6.TangentVector()
-            results6.reserveCapacity(v.count)
-            var results7 = C7.TangentVector()
-            results7.reserveCapacity(v.count)
-            var results8 = C8.TangentVector()
-            results8.reserveCapacity(v.count)
+
+            var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+            var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+            var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+            var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+            var results6 = C6.TangentVector(repeating: .zero, count: v.count)
+            var results7 = C7.TangentVector(repeating: .zero, count: v.count)
+            var results8 = C8.TangentVector(repeating: .zero, count: v.count)
+            var results2Index = results2.startIndex
+            var results3Index = results3.startIndex
+            var results4Index = results4.startIndex
+            var results5Index = results5.startIndex
+            var results6Index = results6.startIndex
+            var results7Index = results7.startIndex
+            var results8Index = results8.startIndex
+
             for (index, (tangentElement, pullback)) in zip(v.indices, zip(v, pullbacks)) {
                 let (v1, v2, v3, v4, v5, v6, v7, v8) = pullback(tangentElement)
                 v[index] = v1
-                results2.appendContribution(of: v2)
-                results3.appendContribution(of: v3)
-                results4.appendContribution(of: v4)
-                results5.appendContribution(of: v5)
-                results6.appendContribution(of: v6)
-                results7.appendContribution(of: v7)
-                results8.appendContribution(of: v8)
+                results2.writeTangentContribution(of: v2, at: results2Index)
+                results3.writeTangentContribution(of: v3, at: results3Index)
+                results4.writeTangentContribution(of: v4, at: results4Index)
+                results5.writeTangentContribution(of: v5, at: results5Index)
+                results6.writeTangentContribution(of: v6, at: results6Index)
+                results7.writeTangentContribution(of: v7, at: results7Index)
+                results8.writeTangentContribution(of: v8, at: results8Index)
+                results2.formIndex(after: &results2Index)
+                results3.formIndex(after: &results3Index)
+                results4.formIndex(after: &results4Index)
+                results5.formIndex(after: &results5Index)
+                results6.formIndex(after: &results6Index)
+                results7.formIndex(after: &results7Index)
+                results8.formIndex(after: &results8Index)
             }
 
             // swiftformat:disable:next redundantParens

--- a/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity9.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity9.swift
@@ -238,33 +238,43 @@ public func _vjpDifferentiableZipWith<Inout, C2, C3, C4, C5, C6, C7, C8, C9>(
         value: (),
         pullback: { v in
             precondition(v.count == pullbacks.count)
-            var results2 = C2.TangentVector()
-            results2.reserveCapacity(v.count)
-            var results3 = C3.TangentVector()
-            results3.reserveCapacity(v.count)
-            var results4 = C4.TangentVector()
-            results4.reserveCapacity(v.count)
-            var results5 = C5.TangentVector()
-            results5.reserveCapacity(v.count)
-            var results6 = C6.TangentVector()
-            results6.reserveCapacity(v.count)
-            var results7 = C7.TangentVector()
-            results7.reserveCapacity(v.count)
-            var results8 = C8.TangentVector()
-            results8.reserveCapacity(v.count)
-            var results9 = C9.TangentVector()
-            results9.reserveCapacity(v.count)
+
+            var results2 = C2.TangentVector(repeating: .zero, count: v.count)
+            var results3 = C3.TangentVector(repeating: .zero, count: v.count)
+            var results4 = C4.TangentVector(repeating: .zero, count: v.count)
+            var results5 = C5.TangentVector(repeating: .zero, count: v.count)
+            var results6 = C6.TangentVector(repeating: .zero, count: v.count)
+            var results7 = C7.TangentVector(repeating: .zero, count: v.count)
+            var results8 = C8.TangentVector(repeating: .zero, count: v.count)
+            var results9 = C9.TangentVector(repeating: .zero, count: v.count)
+            var results2Index = results2.startIndex
+            var results3Index = results3.startIndex
+            var results4Index = results4.startIndex
+            var results5Index = results5.startIndex
+            var results6Index = results6.startIndex
+            var results7Index = results7.startIndex
+            var results8Index = results8.startIndex
+            var results9Index = results9.startIndex
+
             for (index, (tangentElement, pullback)) in zip(v.indices, zip(v, pullbacks)) {
                 let (v1, v2, v3, v4, v5, v6, v7, v8, v9) = pullback(tangentElement)
                 v[index] = v1
-                results2.appendContribution(of: v2)
-                results3.appendContribution(of: v3)
-                results4.appendContribution(of: v4)
-                results5.appendContribution(of: v5)
-                results6.appendContribution(of: v6)
-                results7.appendContribution(of: v7)
-                results8.appendContribution(of: v8)
-                results9.appendContribution(of: v9)
+                results2.writeTangentContribution(of: v2, at: results2Index)
+                results3.writeTangentContribution(of: v3, at: results3Index)
+                results4.writeTangentContribution(of: v4, at: results4Index)
+                results5.writeTangentContribution(of: v5, at: results5Index)
+                results6.writeTangentContribution(of: v6, at: results6Index)
+                results7.writeTangentContribution(of: v7, at: results7Index)
+                results8.writeTangentContribution(of: v8, at: results8Index)
+                results9.writeTangentContribution(of: v9, at: results9Index)
+                results2.formIndex(after: &results2Index)
+                results3.formIndex(after: &results3Index)
+                results4.formIndex(after: &results4Index)
+                results5.formIndex(after: &results5Index)
+                results6.formIndex(after: &results6Index)
+                results7.formIndex(after: &results7Index)
+                results8.formIndex(after: &results8Index)
+                results9.formIndex(after: &results9Index)
             }
 
             // swiftformat:disable:next redundantParens


### PR DESCRIPTION
This simplifies the protocol requirements for DifferentiableSequence but breaks the previous api (people shouldn't have adopted the protocol but it can't be kept internal). The change enables us to conform StencilCollection to DifferentiableCollection.