### PR TITLE
feat: support differentiation on OS's 26.4 and beyond

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,7 @@ jobs:
     name: Test Swift ${{ matrix.swift }} Ubuntu Latest
     strategy:
       matrix:
-        swift: ["6.1.3", "6.2"]
+        swift: ["6.2", "6.3"]
     runs-on: ubuntu-latest
     container: swift:${{ matrix.swift }}
     steps:
@@ -21,46 +21,11 @@ jobs:
       - name: Run Tests
         run: swift test -Xswiftc -warnings-as-errors
 
-  test-macos-15:
-    name: Test Swift ${{ matrix.swift }} macos-15
-    strategy:
-      matrix:
-        swift: ["6.1.3", "6.2"]
-    runs-on: macos-15
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Swiftly
-        run: |
-          curl -O https://download.swift.org/swiftly/darwin/swiftly.pkg && \
-            installer -pkg swiftly.pkg -target CurrentUserHomeDirectory && \
-            ~/.swiftly/bin/swiftly init --quiet-shell-followup && \
-            . ~/.swiftly/env.sh && \
-            hash -r
-      - name: Install Swift ${{ matrix.swift }}
-        run: ~/.swiftly/bin/swiftly install --use ${{ matrix.swift }}
-      - name: Run Tests
-        run: |
-          export PATH=${HOME}/.swiftly/bin:${PATH}
-          swift test -Xswiftc -warnings-as-errors
-
   test-macos-26:
-    name: Test Swift ${{ matrix.swift }} macos-26
-    strategy:
-      matrix:
-        swift: ["6.2"]
+    name: Test Swift macos-26
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
-      - name: Install Swiftly
-        run: |
-          curl -O https://download.swift.org/swiftly/darwin/swiftly.pkg && \
-            installer -pkg swiftly.pkg -target CurrentUserHomeDirectory && \
-            ~/.swiftly/bin/swiftly init --quiet-shell-followup && \
-            . ~/.swiftly/env.sh && \
-            hash -r
-      - name: Install Swift ${{ matrix.swift }}
-        run: ~/.swiftly/bin/swiftly install --use ${{ matrix.swift }}
       - name: Run Tests
         run: |
-          export PATH=${HOME}/.swiftly/bin:${PATH}
           swift test -Xswiftc -warnings-as-errors

--- a/Package.swift
+++ b/Package.swift
@@ -5,17 +5,41 @@ import PackageDescription
 
 let package = Package(
     name: "swift-differentiation",
+    platforms: [
+        .macOS("26.0"),
+        .iOS("26.0"),
+    ],
     products: [
         .library(
             name: "Differentiation",
             targets: ["Differentiation"]
         ),
     ],
+    dependencies: [
+        .package(
+            url: "https://github.com/differentiable-swift/swift-differentiation-stdlib.git", from: .tagBasedOnCompilerVersion
+        ),
+    ],
     targets: [
-        .target(name: "Differentiation"),
+        .target(
+            name: "Differentiation",
+            dependencies: [
+                .product(name: "_Differentiation", package: "swift-differentiation-stdlib", condition: .when(platforms: [.macOS, .iOS])),
+            ]
+        ),
         .testTarget(
             name: "DifferentiationTests",
             dependencies: ["Differentiation"]
         ),
     ]
 )
+
+extension Version {
+    static var tagBasedOnCompilerVersion: Version {
+        #if compiler(<6.3)
+        "602.0.0"
+        #elseif compiler(<6.4)
+        "603.0.0"
+        #endif
+    }
+}

--- a/Tests/DifferentiationTests/Collection+DifferentiableMethodsTests.swift
+++ b/Tests/DifferentiationTests/Collection+DifferentiableMethodsTests.swift
@@ -98,8 +98,6 @@ struct CollectionDifferentiableMethodsTests {
         let gradient4 = pullback2([0, 0, 1, 0, 0])
 
         #expect(gradient3 == gradient4)
-
-        print(gradient1, gradient3)
     }
 
     @Test
@@ -130,8 +128,6 @@ struct CollectionDifferentiableMethodsTests {
         let gradient4 = pullback2([0, 0, 1, 0, 0, 0])
 
         #expect(gradient3 == gradient4)
-
-        print(gradient1, gradient3)
     }
 
     @Test
@@ -162,7 +158,5 @@ struct CollectionDifferentiableMethodsTests {
         let gradient4 = pullback2([0, 0, 1, 0])
 
         #expect(gradient3 == gradient4)
-
-        print(gradient1, gradient3)
     }
 }

--- a/Tests/DifferentiationTests/CollectionTests.swift
+++ b/Tests/DifferentiationTests/CollectionTests.swift
@@ -381,9 +381,15 @@ struct ArrayDifferentiableTests {
             let view = Array<Float>.DifferentiableView([1, 2, 3])
             #expect((view - .zero).base.elementsEqual([1, 2, 3]))
 
-            withKnownIssue("This should be fixed in 6.3") {
-                #expect((Array<Float>.DifferentiableView.zero - view).base.elementsEqual([-1, -2, -3]))
+            let check = (Array<Float>.DifferentiableView.zero - view).base.elementsEqual([-1, -2, -3])
+
+            #if compiler(<6.3)
+            withKnownIssue("This is fixed in Swift 6.3. But currently using Swift<6.3") {
+                #expect(check)
             }
+            #else
+            #expect(check)
+            #endif
         }
 
         @Test("subtracting empty view from non-empty view returns non-empty")

--- a/Tests/DifferentiationTests/Repeated+DifferentiableTests.swift
+++ b/Tests/DifferentiationTests/Repeated+DifferentiableTests.swift
@@ -37,7 +37,6 @@ struct RepeatedDifferentiableTests {
         let vb: Repeated<Double>.DifferentiableView = .init(base: repeatElement(2.0, count: 3))
 
         let gradient = pullback(Zip2SequenceDifferentiable<[Double], Repeated<Double>>.TangentVector(va, vb))
-        print(gradient)
         #expect(gradient.0 == [1, 0, 0])
         #expect(gradient.1.base.repeatedValue == 2.0)
         #expect(gradient.1.count == 3)


### PR DESCRIPTION
This adds a dependency on the stdlib's _Differentiation module through a static library so that we can support differentiation on macOS/iOS 26.4 and beyond.