### PR TITLE
ci: Add WebAssembly compilation check

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -29,3 +29,17 @@ jobs:
       - name: Run Tests
         run: |
           swift test -Xswiftc -warnings-as-errors
+
+  test-wasm:
+    name: WASM compilation check
+    runs-on: ubuntu-latest
+    container:
+      image: swift:6.3
+    steps:
+      - uses: actions/checkout@v4
+      - uses: swiftwasm/setup-swiftwasm@v2
+        id: setup-swiftwasm
+        with:
+          target: wasm32-unknown-wasip1
+      - name: Build for WebAssembly
+        run: swift build --swift-sdk ${{ steps.setup-swiftwasm.outputs.swift-sdk-id }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,14 +32,9 @@ jobs:
 
   test-wasm:
     name: WASM compilation check
-    runs-on: ubuntu-latest
-    container:
-      image: swift:6.3
-    steps:
-      - uses: actions/checkout@v4
-      - uses: swiftwasm/setup-swiftwasm@v2
-        id: setup-swiftwasm
-        with:
-          target: wasm32-unknown-wasip1
-      - name: Build for WebAssembly
-        run: swift build --swift-sdk ${{ steps.setup-swiftwasm.outputs.swift-sdk-id }}
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@0.0.11
+    with:
+      enable_linux_checks: false
+      enable_windows_checks: false
+      enable_wasm_sdk_build: true
+      wasm_sdk_versions: "[\"6.3\"]"


### PR DESCRIPTION
## Overview

At PassiveLogic we're adopting CI-level WebAssembly compilation checks across our Swift repositories, so that the WASM build is continuously verified as code evolves (WebAssembly is one of our deployment targets). This PR is a natural extension of that effort to `swift-differentiation`, requested by @JaapWijnen, and follows the same approach we use elsewhere (e.g. in JavaScriptKit).

It adds a CI job that builds the package for WebAssembly on every pull request, so a change that breaks the WASM build is caught here rather than downstream.

## What this verifies

The open-source Swift toolchain's WebAssembly SDK ships the `_Differentiation` module (`_Differentiation.swiftmodule` + `libswift_Differentiation.a`), so `#if canImport(_Differentiation)` is satisfied on WASM and the differentiation code actually compiles (it is not stubbed out). The existing `swift-differentiation-stdlib` xcframework dependency stays correctly scoped to macOS/iOS (xcframeworks are Apple-only, and Apple release toolchains do not bundle `_Differentiation`); on WASM/Linux the toolchain provides the module instead. No `Package.swift` change is required.

## What changed

- **`.github/workflows/pull_request.yml`** - new `test-wasm` job. It runs in the `swift:6.3` container, installs the matching WebAssembly Swift SDK via [`swiftwasm/setup-swiftwasm`](https://github.com/swiftwasm/setup-swiftwasm), and runs `swift build --swift-sdk <id>` for `wasm32-unknown-wasip1`.

## Tested

- Built locally against the 6.3 WebAssembly SDK: the `Differentiation` target compiles clean, with the `_Differentiation`-guarded sources (e.g. `Array+Update.swift`, `Dictionary+Update.swift`, `Differentiation.swift`) actually compiling.

## Notes

- Scoped to Swift 6.3 to match the validated toolchain; happy to extend the job to a `["6.2", "6.3"]` matrix to mirror the existing Ubuntu test jobs if preferred.