### PR TITLE
perf: Reduce compile time by avoiding variadic `min()` usage

### DIFF
--- a/DifferentiableZipCodeGenerator/Sources/DifferentiableZipCodeGenerator/ZipSequenceGenerator.swift
+++ b/DifferentiableZipCodeGenerator/Sources/DifferentiableZipCodeGenerator/ZipSequenceGenerator.swift
@@ -68,9 +68,9 @@ enum ZipSequenceGenerator {
             public var startIndex: Int { 0 }
             @inlinable
             public var endIndex: Int {
-                Swift.min(
-        \(arityRange.map { "\(indent(3))_collection\($0).count" }.joined(separator: ",\n"))
-                )
+                var result = _collection1.count
+        \(arityRange.dropFirst().map { "\(indent(2))result = Swift.min(result, _collection\($0).count)" }.joined(separator: "\n"))
+                return result
             }
 
             @inlinable
@@ -259,9 +259,9 @@ enum ZipSequenceGenerator {
                 public var startIndex: Int { 0 }
                 @inlinable
                 public var endIndex: Int {
-                    Swift.min(
-        \(arityRange.map { "\(indent(4))collection\($0).count" }.joined(separator: ",\n"))
-                    )
+                    var result = collection1.count
+        \(arityRange.dropFirst().map { "\(indent(3))result = Swift.min(result, collection\($0).count)" }.joined(separator: "\n"))
+                    return result
                 }
 
                 @inlinable

--- a/DifferentiableZipCodeGenerator/Sources/DifferentiableZipCodeGenerator/ZipWithGenerator.swift
+++ b/DifferentiableZipCodeGenerator/Sources/DifferentiableZipCodeGenerator/ZipWithGenerator.swift
@@ -26,9 +26,8 @@ enum ZipWithGenerator {
 
             Result: Differentiable
         {
-            let capacity = min(
-        \(arityRange.map { "\(indent(2))c\($0).count" }.joined(separator: ",\n"))
-            )
+            var capacity = c1.count
+        \(arityRange.dropFirst().map { "\(indent(1))capacity = Swift.min(capacity, c\($0).count)" }.joined(separator: "\n"))
 
             if capacity == 0 { return [] }
 
@@ -72,9 +71,8 @@ enum ZipWithGenerator {
 
             Result: Differentiable
         {
-            let count = min(
-        \(arityRange.map { "\(indent(2))c\($0).count" }.joined(separator: ",\n"))
-            )
+            var count = c1.count
+        \(arityRange.dropFirst().map { "\(indent(1))count = Swift.min(count, c\($0).count)" }.joined(separator: "\n"))
 
             if count == 0 {
                 return (

--- a/DifferentiableZipCodeGenerator/Sources/DifferentiableZipCodeGenerator/ZipWithInoutGenerator.swift
+++ b/DifferentiableZipCodeGenerator/Sources/DifferentiableZipCodeGenerator/ZipWithInoutGenerator.swift
@@ -30,10 +30,8 @@ enum ZipWithInoutGenerator {
         code += """
 
         {
-            let capacity = min(
-                c1.count,
-        \(arityRange.map { "\(indent(2))c\($0).count" }.joined(separator: ",\n"))
-            )
+            var capacity = c1.count
+        \(arityRange.map { "\(indent(1))capacity = Swift.min(capacity, c\($0).count)" }.joined(separator: "\n"))
 
             if capacity == 0 { return }
 
@@ -80,10 +78,8 @@ enum ZipWithInoutGenerator {
         code += """
 
         {
-            let count = min(
-                c1.count,
-        \(arityRange.map { "\(indent(2))c\($0).count" }.joined(separator: ",\n"))
-            )
+            var count = c1.count
+        \(arityRange.map { "\(indent(1))count = Swift.min(count, c\($0).count)" }.joined(separator: "\n"))
 
             if count == 0 {
                 return (

--- a/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity10.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity10.swift
@@ -126,18 +126,17 @@ extension Zip10SequenceDifferentiable: Collection {
     public var startIndex: Int { 0 }
     @inlinable
     public var endIndex: Int {
-        Swift.min(
-            _collection1.count,
-            _collection2.count,
-            _collection3.count,
-            _collection4.count,
-            _collection5.count,
-            _collection6.count,
-            _collection7.count,
-            _collection8.count,
-            _collection9.count,
-            _collection10.count
-        )
+        var result = _collection1.count
+        result = Swift.min(result, _collection2.count)
+        result = Swift.min(result, _collection3.count)
+        result = Swift.min(result, _collection4.count)
+        result = Swift.min(result, _collection5.count)
+        result = Swift.min(result, _collection6.count)
+        result = Swift.min(result, _collection7.count)
+        result = Swift.min(result, _collection8.count)
+        result = Swift.min(result, _collection9.count)
+        result = Swift.min(result, _collection10.count)
+        return result
     }
 
     @inlinable
@@ -562,18 +561,17 @@ extension Zip10SequenceDifferentiable {
         public var startIndex: Int { 0 }
         @inlinable
         public var endIndex: Int {
-            Swift.min(
-                collection1.count,
-                collection2.count,
-                collection3.count,
-                collection4.count,
-                collection5.count,
-                collection6.count,
-                collection7.count,
-                collection8.count,
-                collection9.count,
-                collection10.count
-            )
+            var result = collection1.count
+            result = Swift.min(result, collection2.count)
+            result = Swift.min(result, collection3.count)
+            result = Swift.min(result, collection4.count)
+            result = Swift.min(result, collection5.count)
+            result = Swift.min(result, collection6.count)
+            result = Swift.min(result, collection7.count)
+            result = Swift.min(result, collection8.count)
+            result = Swift.min(result, collection9.count)
+            result = Swift.min(result, collection10.count)
+            return result
         }
 
         @inlinable

--- a/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity11.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity11.swift
@@ -136,19 +136,18 @@ extension Zip11SequenceDifferentiable: Collection {
     public var startIndex: Int { 0 }
     @inlinable
     public var endIndex: Int {
-        Swift.min(
-            _collection1.count,
-            _collection2.count,
-            _collection3.count,
-            _collection4.count,
-            _collection5.count,
-            _collection6.count,
-            _collection7.count,
-            _collection8.count,
-            _collection9.count,
-            _collection10.count,
-            _collection11.count
-        )
+        var result = _collection1.count
+        result = Swift.min(result, _collection2.count)
+        result = Swift.min(result, _collection3.count)
+        result = Swift.min(result, _collection4.count)
+        result = Swift.min(result, _collection5.count)
+        result = Swift.min(result, _collection6.count)
+        result = Swift.min(result, _collection7.count)
+        result = Swift.min(result, _collection8.count)
+        result = Swift.min(result, _collection9.count)
+        result = Swift.min(result, _collection10.count)
+        result = Swift.min(result, _collection11.count)
+        return result
     }
 
     @inlinable
@@ -603,19 +602,18 @@ extension Zip11SequenceDifferentiable {
         public var startIndex: Int { 0 }
         @inlinable
         public var endIndex: Int {
-            Swift.min(
-                collection1.count,
-                collection2.count,
-                collection3.count,
-                collection4.count,
-                collection5.count,
-                collection6.count,
-                collection7.count,
-                collection8.count,
-                collection9.count,
-                collection10.count,
-                collection11.count
-            )
+            var result = collection1.count
+            result = Swift.min(result, collection2.count)
+            result = Swift.min(result, collection3.count)
+            result = Swift.min(result, collection4.count)
+            result = Swift.min(result, collection5.count)
+            result = Swift.min(result, collection6.count)
+            result = Swift.min(result, collection7.count)
+            result = Swift.min(result, collection8.count)
+            result = Swift.min(result, collection9.count)
+            result = Swift.min(result, collection10.count)
+            result = Swift.min(result, collection11.count)
+            return result
         }
 
         @inlinable

--- a/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity12.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity12.swift
@@ -146,20 +146,19 @@ extension Zip12SequenceDifferentiable: Collection {
     public var startIndex: Int { 0 }
     @inlinable
     public var endIndex: Int {
-        Swift.min(
-            _collection1.count,
-            _collection2.count,
-            _collection3.count,
-            _collection4.count,
-            _collection5.count,
-            _collection6.count,
-            _collection7.count,
-            _collection8.count,
-            _collection9.count,
-            _collection10.count,
-            _collection11.count,
-            _collection12.count
-        )
+        var result = _collection1.count
+        result = Swift.min(result, _collection2.count)
+        result = Swift.min(result, _collection3.count)
+        result = Swift.min(result, _collection4.count)
+        result = Swift.min(result, _collection5.count)
+        result = Swift.min(result, _collection6.count)
+        result = Swift.min(result, _collection7.count)
+        result = Swift.min(result, _collection8.count)
+        result = Swift.min(result, _collection9.count)
+        result = Swift.min(result, _collection10.count)
+        result = Swift.min(result, _collection11.count)
+        result = Swift.min(result, _collection12.count)
+        return result
     }
 
     @inlinable
@@ -644,20 +643,19 @@ extension Zip12SequenceDifferentiable {
         public var startIndex: Int { 0 }
         @inlinable
         public var endIndex: Int {
-            Swift.min(
-                collection1.count,
-                collection2.count,
-                collection3.count,
-                collection4.count,
-                collection5.count,
-                collection6.count,
-                collection7.count,
-                collection8.count,
-                collection9.count,
-                collection10.count,
-                collection11.count,
-                collection12.count
-            )
+            var result = collection1.count
+            result = Swift.min(result, collection2.count)
+            result = Swift.min(result, collection3.count)
+            result = Swift.min(result, collection4.count)
+            result = Swift.min(result, collection5.count)
+            result = Swift.min(result, collection6.count)
+            result = Swift.min(result, collection7.count)
+            result = Swift.min(result, collection8.count)
+            result = Swift.min(result, collection9.count)
+            result = Swift.min(result, collection10.count)
+            result = Swift.min(result, collection11.count)
+            result = Swift.min(result, collection12.count)
+            return result
         }
 
         @inlinable

--- a/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity13.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity13.swift
@@ -156,21 +156,20 @@ extension Zip13SequenceDifferentiable: Collection {
     public var startIndex: Int { 0 }
     @inlinable
     public var endIndex: Int {
-        Swift.min(
-            _collection1.count,
-            _collection2.count,
-            _collection3.count,
-            _collection4.count,
-            _collection5.count,
-            _collection6.count,
-            _collection7.count,
-            _collection8.count,
-            _collection9.count,
-            _collection10.count,
-            _collection11.count,
-            _collection12.count,
-            _collection13.count
-        )
+        var result = _collection1.count
+        result = Swift.min(result, _collection2.count)
+        result = Swift.min(result, _collection3.count)
+        result = Swift.min(result, _collection4.count)
+        result = Swift.min(result, _collection5.count)
+        result = Swift.min(result, _collection6.count)
+        result = Swift.min(result, _collection7.count)
+        result = Swift.min(result, _collection8.count)
+        result = Swift.min(result, _collection9.count)
+        result = Swift.min(result, _collection10.count)
+        result = Swift.min(result, _collection11.count)
+        result = Swift.min(result, _collection12.count)
+        result = Swift.min(result, _collection13.count)
+        return result
     }
 
     @inlinable
@@ -685,21 +684,20 @@ extension Zip13SequenceDifferentiable {
         public var startIndex: Int { 0 }
         @inlinable
         public var endIndex: Int {
-            Swift.min(
-                collection1.count,
-                collection2.count,
-                collection3.count,
-                collection4.count,
-                collection5.count,
-                collection6.count,
-                collection7.count,
-                collection8.count,
-                collection9.count,
-                collection10.count,
-                collection11.count,
-                collection12.count,
-                collection13.count
-            )
+            var result = collection1.count
+            result = Swift.min(result, collection2.count)
+            result = Swift.min(result, collection3.count)
+            result = Swift.min(result, collection4.count)
+            result = Swift.min(result, collection5.count)
+            result = Swift.min(result, collection6.count)
+            result = Swift.min(result, collection7.count)
+            result = Swift.min(result, collection8.count)
+            result = Swift.min(result, collection9.count)
+            result = Swift.min(result, collection10.count)
+            result = Swift.min(result, collection11.count)
+            result = Swift.min(result, collection12.count)
+            result = Swift.min(result, collection13.count)
+            return result
         }
 
         @inlinable

--- a/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity14.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity14.swift
@@ -166,22 +166,21 @@ extension Zip14SequenceDifferentiable: Collection {
     public var startIndex: Int { 0 }
     @inlinable
     public var endIndex: Int {
-        Swift.min(
-            _collection1.count,
-            _collection2.count,
-            _collection3.count,
-            _collection4.count,
-            _collection5.count,
-            _collection6.count,
-            _collection7.count,
-            _collection8.count,
-            _collection9.count,
-            _collection10.count,
-            _collection11.count,
-            _collection12.count,
-            _collection13.count,
-            _collection14.count
-        )
+        var result = _collection1.count
+        result = Swift.min(result, _collection2.count)
+        result = Swift.min(result, _collection3.count)
+        result = Swift.min(result, _collection4.count)
+        result = Swift.min(result, _collection5.count)
+        result = Swift.min(result, _collection6.count)
+        result = Swift.min(result, _collection7.count)
+        result = Swift.min(result, _collection8.count)
+        result = Swift.min(result, _collection9.count)
+        result = Swift.min(result, _collection10.count)
+        result = Swift.min(result, _collection11.count)
+        result = Swift.min(result, _collection12.count)
+        result = Swift.min(result, _collection13.count)
+        result = Swift.min(result, _collection14.count)
+        return result
     }
 
     @inlinable
@@ -726,22 +725,21 @@ extension Zip14SequenceDifferentiable {
         public var startIndex: Int { 0 }
         @inlinable
         public var endIndex: Int {
-            Swift.min(
-                collection1.count,
-                collection2.count,
-                collection3.count,
-                collection4.count,
-                collection5.count,
-                collection6.count,
-                collection7.count,
-                collection8.count,
-                collection9.count,
-                collection10.count,
-                collection11.count,
-                collection12.count,
-                collection13.count,
-                collection14.count
-            )
+            var result = collection1.count
+            result = Swift.min(result, collection2.count)
+            result = Swift.min(result, collection3.count)
+            result = Swift.min(result, collection4.count)
+            result = Swift.min(result, collection5.count)
+            result = Swift.min(result, collection6.count)
+            result = Swift.min(result, collection7.count)
+            result = Swift.min(result, collection8.count)
+            result = Swift.min(result, collection9.count)
+            result = Swift.min(result, collection10.count)
+            result = Swift.min(result, collection11.count)
+            result = Swift.min(result, collection12.count)
+            result = Swift.min(result, collection13.count)
+            result = Swift.min(result, collection14.count)
+            return result
         }
 
         @inlinable

--- a/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity2.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity2.swift
@@ -46,10 +46,9 @@ extension Zip2SequenceDifferentiable: Collection {
     public var startIndex: Int { 0 }
     @inlinable
     public var endIndex: Int {
-        Swift.min(
-            _collection1.count,
-            _collection2.count
-        )
+        var result = _collection1.count
+        result = Swift.min(result, _collection2.count)
+        return result
     }
 
     @inlinable
@@ -234,10 +233,9 @@ extension Zip2SequenceDifferentiable {
         public var startIndex: Int { 0 }
         @inlinable
         public var endIndex: Int {
-            Swift.min(
-                collection1.count,
-                collection2.count
-            )
+            var result = collection1.count
+            result = Swift.min(result, collection2.count)
+            return result
         }
 
         @inlinable

--- a/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity3.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity3.swift
@@ -56,11 +56,10 @@ extension Zip3SequenceDifferentiable: Collection {
     public var startIndex: Int { 0 }
     @inlinable
     public var endIndex: Int {
-        Swift.min(
-            _collection1.count,
-            _collection2.count,
-            _collection3.count
-        )
+        var result = _collection1.count
+        result = Swift.min(result, _collection2.count)
+        result = Swift.min(result, _collection3.count)
+        return result
     }
 
     @inlinable
@@ -275,11 +274,10 @@ extension Zip3SequenceDifferentiable {
         public var startIndex: Int { 0 }
         @inlinable
         public var endIndex: Int {
-            Swift.min(
-                collection1.count,
-                collection2.count,
-                collection3.count
-            )
+            var result = collection1.count
+            result = Swift.min(result, collection2.count)
+            result = Swift.min(result, collection3.count)
+            return result
         }
 
         @inlinable

--- a/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity4.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity4.swift
@@ -66,12 +66,11 @@ extension Zip4SequenceDifferentiable: Collection {
     public var startIndex: Int { 0 }
     @inlinable
     public var endIndex: Int {
-        Swift.min(
-            _collection1.count,
-            _collection2.count,
-            _collection3.count,
-            _collection4.count
-        )
+        var result = _collection1.count
+        result = Swift.min(result, _collection2.count)
+        result = Swift.min(result, _collection3.count)
+        result = Swift.min(result, _collection4.count)
+        return result
     }
 
     @inlinable
@@ -316,12 +315,11 @@ extension Zip4SequenceDifferentiable {
         public var startIndex: Int { 0 }
         @inlinable
         public var endIndex: Int {
-            Swift.min(
-                collection1.count,
-                collection2.count,
-                collection3.count,
-                collection4.count
-            )
+            var result = collection1.count
+            result = Swift.min(result, collection2.count)
+            result = Swift.min(result, collection3.count)
+            result = Swift.min(result, collection4.count)
+            return result
         }
 
         @inlinable

--- a/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity5.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity5.swift
@@ -76,13 +76,12 @@ extension Zip5SequenceDifferentiable: Collection {
     public var startIndex: Int { 0 }
     @inlinable
     public var endIndex: Int {
-        Swift.min(
-            _collection1.count,
-            _collection2.count,
-            _collection3.count,
-            _collection4.count,
-            _collection5.count
-        )
+        var result = _collection1.count
+        result = Swift.min(result, _collection2.count)
+        result = Swift.min(result, _collection3.count)
+        result = Swift.min(result, _collection4.count)
+        result = Swift.min(result, _collection5.count)
+        return result
     }
 
     @inlinable
@@ -357,13 +356,12 @@ extension Zip5SequenceDifferentiable {
         public var startIndex: Int { 0 }
         @inlinable
         public var endIndex: Int {
-            Swift.min(
-                collection1.count,
-                collection2.count,
-                collection3.count,
-                collection4.count,
-                collection5.count
-            )
+            var result = collection1.count
+            result = Swift.min(result, collection2.count)
+            result = Swift.min(result, collection3.count)
+            result = Swift.min(result, collection4.count)
+            result = Swift.min(result, collection5.count)
+            return result
         }
 
         @inlinable

--- a/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity6.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity6.swift
@@ -86,14 +86,13 @@ extension Zip6SequenceDifferentiable: Collection {
     public var startIndex: Int { 0 }
     @inlinable
     public var endIndex: Int {
-        Swift.min(
-            _collection1.count,
-            _collection2.count,
-            _collection3.count,
-            _collection4.count,
-            _collection5.count,
-            _collection6.count
-        )
+        var result = _collection1.count
+        result = Swift.min(result, _collection2.count)
+        result = Swift.min(result, _collection3.count)
+        result = Swift.min(result, _collection4.count)
+        result = Swift.min(result, _collection5.count)
+        result = Swift.min(result, _collection6.count)
+        return result
     }
 
     @inlinable
@@ -398,14 +397,13 @@ extension Zip6SequenceDifferentiable {
         public var startIndex: Int { 0 }
         @inlinable
         public var endIndex: Int {
-            Swift.min(
-                collection1.count,
-                collection2.count,
-                collection3.count,
-                collection4.count,
-                collection5.count,
-                collection6.count
-            )
+            var result = collection1.count
+            result = Swift.min(result, collection2.count)
+            result = Swift.min(result, collection3.count)
+            result = Swift.min(result, collection4.count)
+            result = Swift.min(result, collection5.count)
+            result = Swift.min(result, collection6.count)
+            return result
         }
 
         @inlinable

--- a/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity7.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity7.swift
@@ -96,15 +96,14 @@ extension Zip7SequenceDifferentiable: Collection {
     public var startIndex: Int { 0 }
     @inlinable
     public var endIndex: Int {
-        Swift.min(
-            _collection1.count,
-            _collection2.count,
-            _collection3.count,
-            _collection4.count,
-            _collection5.count,
-            _collection6.count,
-            _collection7.count
-        )
+        var result = _collection1.count
+        result = Swift.min(result, _collection2.count)
+        result = Swift.min(result, _collection3.count)
+        result = Swift.min(result, _collection4.count)
+        result = Swift.min(result, _collection5.count)
+        result = Swift.min(result, _collection6.count)
+        result = Swift.min(result, _collection7.count)
+        return result
     }
 
     @inlinable
@@ -439,15 +438,14 @@ extension Zip7SequenceDifferentiable {
         public var startIndex: Int { 0 }
         @inlinable
         public var endIndex: Int {
-            Swift.min(
-                collection1.count,
-                collection2.count,
-                collection3.count,
-                collection4.count,
-                collection5.count,
-                collection6.count,
-                collection7.count
-            )
+            var result = collection1.count
+            result = Swift.min(result, collection2.count)
+            result = Swift.min(result, collection3.count)
+            result = Swift.min(result, collection4.count)
+            result = Swift.min(result, collection5.count)
+            result = Swift.min(result, collection6.count)
+            result = Swift.min(result, collection7.count)
+            return result
         }
 
         @inlinable

--- a/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity8.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity8.swift
@@ -106,16 +106,15 @@ extension Zip8SequenceDifferentiable: Collection {
     public var startIndex: Int { 0 }
     @inlinable
     public var endIndex: Int {
-        Swift.min(
-            _collection1.count,
-            _collection2.count,
-            _collection3.count,
-            _collection4.count,
-            _collection5.count,
-            _collection6.count,
-            _collection7.count,
-            _collection8.count
-        )
+        var result = _collection1.count
+        result = Swift.min(result, _collection2.count)
+        result = Swift.min(result, _collection3.count)
+        result = Swift.min(result, _collection4.count)
+        result = Swift.min(result, _collection5.count)
+        result = Swift.min(result, _collection6.count)
+        result = Swift.min(result, _collection7.count)
+        result = Swift.min(result, _collection8.count)
+        return result
     }
 
     @inlinable
@@ -480,16 +479,15 @@ extension Zip8SequenceDifferentiable {
         public var startIndex: Int { 0 }
         @inlinable
         public var endIndex: Int {
-            Swift.min(
-                collection1.count,
-                collection2.count,
-                collection3.count,
-                collection4.count,
-                collection5.count,
-                collection6.count,
-                collection7.count,
-                collection8.count
-            )
+            var result = collection1.count
+            result = Swift.min(result, collection2.count)
+            result = Swift.min(result, collection3.count)
+            result = Swift.min(result, collection4.count)
+            result = Swift.min(result, collection5.count)
+            result = Swift.min(result, collection6.count)
+            result = Swift.min(result, collection7.count)
+            result = Swift.min(result, collection8.count)
+            return result
         }
 
         @inlinable

--- a/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity9.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipSequence+Arity9.swift
@@ -116,17 +116,16 @@ extension Zip9SequenceDifferentiable: Collection {
     public var startIndex: Int { 0 }
     @inlinable
     public var endIndex: Int {
-        Swift.min(
-            _collection1.count,
-            _collection2.count,
-            _collection3.count,
-            _collection4.count,
-            _collection5.count,
-            _collection6.count,
-            _collection7.count,
-            _collection8.count,
-            _collection9.count
-        )
+        var result = _collection1.count
+        result = Swift.min(result, _collection2.count)
+        result = Swift.min(result, _collection3.count)
+        result = Swift.min(result, _collection4.count)
+        result = Swift.min(result, _collection5.count)
+        result = Swift.min(result, _collection6.count)
+        result = Swift.min(result, _collection7.count)
+        result = Swift.min(result, _collection8.count)
+        result = Swift.min(result, _collection9.count)
+        return result
     }
 
     @inlinable
@@ -521,17 +520,16 @@ extension Zip9SequenceDifferentiable {
         public var startIndex: Int { 0 }
         @inlinable
         public var endIndex: Int {
-            Swift.min(
-                collection1.count,
-                collection2.count,
-                collection3.count,
-                collection4.count,
-                collection5.count,
-                collection6.count,
-                collection7.count,
-                collection8.count,
-                collection9.count
-            )
+            var result = collection1.count
+            result = Swift.min(result, collection2.count)
+            result = Swift.min(result, collection3.count)
+            result = Swift.min(result, collection4.count)
+            result = Swift.min(result, collection5.count)
+            result = Swift.min(result, collection6.count)
+            result = Swift.min(result, collection7.count)
+            result = Swift.min(result, collection8.count)
+            result = Swift.min(result, collection9.count)
+            return result
         }
 
         @inlinable

--- a/Sources/Differentiation/DifferentiableZip/ZipWith+Arity10.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWith+Arity10.swift
@@ -49,18 +49,16 @@ public func differentiableZipWith<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, Resul
     C10.Element: Differentiable,
     Result: Differentiable
 {
-    let capacity = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count,
-        c9.count,
-        c10.count
-    )
+    var capacity = c1.count
+    capacity = Swift.min(capacity, c2.count)
+    capacity = Swift.min(capacity, c3.count)
+    capacity = Swift.min(capacity, c4.count)
+    capacity = Swift.min(capacity, c5.count)
+    capacity = Swift.min(capacity, c6.count)
+    capacity = Swift.min(capacity, c7.count)
+    capacity = Swift.min(capacity, c8.count)
+    capacity = Swift.min(capacity, c9.count)
+    capacity = Swift.min(capacity, c10.count)
 
     if capacity == 0 { return [] }
 
@@ -168,18 +166,16 @@ public func _vjpDifferentiableZipWith<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, R
     C10.Element: Differentiable,
     Result: Differentiable
 {
-    let count = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count,
-        c9.count,
-        c10.count
-    )
+    var count = c1.count
+    count = Swift.min(count, c2.count)
+    count = Swift.min(count, c3.count)
+    count = Swift.min(count, c4.count)
+    count = Swift.min(count, c5.count)
+    count = Swift.min(count, c6.count)
+    count = Swift.min(count, c7.count)
+    count = Swift.min(count, c8.count)
+    count = Swift.min(count, c9.count)
+    count = Swift.min(count, c10.count)
 
     if count == 0 {
         return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWith+Arity11.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWith+Arity11.swift
@@ -53,19 +53,17 @@ public func differentiableZipWith<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, 
     C11.Element: Differentiable,
     Result: Differentiable
 {
-    let capacity = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count,
-        c9.count,
-        c10.count,
-        c11.count
-    )
+    var capacity = c1.count
+    capacity = Swift.min(capacity, c2.count)
+    capacity = Swift.min(capacity, c3.count)
+    capacity = Swift.min(capacity, c4.count)
+    capacity = Swift.min(capacity, c5.count)
+    capacity = Swift.min(capacity, c6.count)
+    capacity = Swift.min(capacity, c7.count)
+    capacity = Swift.min(capacity, c8.count)
+    capacity = Swift.min(capacity, c9.count)
+    capacity = Swift.min(capacity, c10.count)
+    capacity = Swift.min(capacity, c11.count)
 
     if capacity == 0 { return [] }
 
@@ -181,19 +179,17 @@ public func _vjpDifferentiableZipWith<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C
     C11.Element: Differentiable,
     Result: Differentiable
 {
-    let count = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count,
-        c9.count,
-        c10.count,
-        c11.count
-    )
+    var count = c1.count
+    count = Swift.min(count, c2.count)
+    count = Swift.min(count, c3.count)
+    count = Swift.min(count, c4.count)
+    count = Swift.min(count, c5.count)
+    count = Swift.min(count, c6.count)
+    count = Swift.min(count, c7.count)
+    count = Swift.min(count, c8.count)
+    count = Swift.min(count, c9.count)
+    count = Swift.min(count, c10.count)
+    count = Swift.min(count, c11.count)
 
     if count == 0 {
         return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWith+Arity12.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWith+Arity12.swift
@@ -57,20 +57,18 @@ public func differentiableZipWith<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, 
     C12.Element: Differentiable,
     Result: Differentiable
 {
-    let capacity = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count,
-        c9.count,
-        c10.count,
-        c11.count,
-        c12.count
-    )
+    var capacity = c1.count
+    capacity = Swift.min(capacity, c2.count)
+    capacity = Swift.min(capacity, c3.count)
+    capacity = Swift.min(capacity, c4.count)
+    capacity = Swift.min(capacity, c5.count)
+    capacity = Swift.min(capacity, c6.count)
+    capacity = Swift.min(capacity, c7.count)
+    capacity = Swift.min(capacity, c8.count)
+    capacity = Swift.min(capacity, c9.count)
+    capacity = Swift.min(capacity, c10.count)
+    capacity = Swift.min(capacity, c11.count)
+    capacity = Swift.min(capacity, c12.count)
 
     if capacity == 0 { return [] }
 
@@ -194,20 +192,18 @@ public func _vjpDifferentiableZipWith<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C
     C12.Element: Differentiable,
     Result: Differentiable
 {
-    let count = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count,
-        c9.count,
-        c10.count,
-        c11.count,
-        c12.count
-    )
+    var count = c1.count
+    count = Swift.min(count, c2.count)
+    count = Swift.min(count, c3.count)
+    count = Swift.min(count, c4.count)
+    count = Swift.min(count, c5.count)
+    count = Swift.min(count, c6.count)
+    count = Swift.min(count, c7.count)
+    count = Swift.min(count, c8.count)
+    count = Swift.min(count, c9.count)
+    count = Swift.min(count, c10.count)
+    count = Swift.min(count, c11.count)
+    count = Swift.min(count, c12.count)
 
     if count == 0 {
         return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWith+Arity13.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWith+Arity13.swift
@@ -61,21 +61,19 @@ public func differentiableZipWith<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, 
     C13.Element: Differentiable,
     Result: Differentiable
 {
-    let capacity = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count,
-        c9.count,
-        c10.count,
-        c11.count,
-        c12.count,
-        c13.count
-    )
+    var capacity = c1.count
+    capacity = Swift.min(capacity, c2.count)
+    capacity = Swift.min(capacity, c3.count)
+    capacity = Swift.min(capacity, c4.count)
+    capacity = Swift.min(capacity, c5.count)
+    capacity = Swift.min(capacity, c6.count)
+    capacity = Swift.min(capacity, c7.count)
+    capacity = Swift.min(capacity, c8.count)
+    capacity = Swift.min(capacity, c9.count)
+    capacity = Swift.min(capacity, c10.count)
+    capacity = Swift.min(capacity, c11.count)
+    capacity = Swift.min(capacity, c12.count)
+    capacity = Swift.min(capacity, c13.count)
 
     if capacity == 0 { return [] }
 
@@ -207,21 +205,19 @@ public func _vjpDifferentiableZipWith<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C
     C13.Element: Differentiable,
     Result: Differentiable
 {
-    let count = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count,
-        c9.count,
-        c10.count,
-        c11.count,
-        c12.count,
-        c13.count
-    )
+    var count = c1.count
+    count = Swift.min(count, c2.count)
+    count = Swift.min(count, c3.count)
+    count = Swift.min(count, c4.count)
+    count = Swift.min(count, c5.count)
+    count = Swift.min(count, c6.count)
+    count = Swift.min(count, c7.count)
+    count = Swift.min(count, c8.count)
+    count = Swift.min(count, c9.count)
+    count = Swift.min(count, c10.count)
+    count = Swift.min(count, c11.count)
+    count = Swift.min(count, c12.count)
+    count = Swift.min(count, c13.count)
 
     if count == 0 {
         return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWith+Arity14.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWith+Arity14.swift
@@ -65,22 +65,20 @@ public func differentiableZipWith<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C11, 
     C14.Element: Differentiable,
     Result: Differentiable
 {
-    let capacity = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count,
-        c9.count,
-        c10.count,
-        c11.count,
-        c12.count,
-        c13.count,
-        c14.count
-    )
+    var capacity = c1.count
+    capacity = Swift.min(capacity, c2.count)
+    capacity = Swift.min(capacity, c3.count)
+    capacity = Swift.min(capacity, c4.count)
+    capacity = Swift.min(capacity, c5.count)
+    capacity = Swift.min(capacity, c6.count)
+    capacity = Swift.min(capacity, c7.count)
+    capacity = Swift.min(capacity, c8.count)
+    capacity = Swift.min(capacity, c9.count)
+    capacity = Swift.min(capacity, c10.count)
+    capacity = Swift.min(capacity, c11.count)
+    capacity = Swift.min(capacity, c12.count)
+    capacity = Swift.min(capacity, c13.count)
+    capacity = Swift.min(capacity, c14.count)
 
     if capacity == 0 { return [] }
 
@@ -220,22 +218,20 @@ public func _vjpDifferentiableZipWith<C1, C2, C3, C4, C5, C6, C7, C8, C9, C10, C
     C14.Element: Differentiable,
     Result: Differentiable
 {
-    let count = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count,
-        c9.count,
-        c10.count,
-        c11.count,
-        c12.count,
-        c13.count,
-        c14.count
-    )
+    var count = c1.count
+    count = Swift.min(count, c2.count)
+    count = Swift.min(count, c3.count)
+    count = Swift.min(count, c4.count)
+    count = Swift.min(count, c5.count)
+    count = Swift.min(count, c6.count)
+    count = Swift.min(count, c7.count)
+    count = Swift.min(count, c8.count)
+    count = Swift.min(count, c9.count)
+    count = Swift.min(count, c10.count)
+    count = Swift.min(count, c11.count)
+    count = Swift.min(count, c12.count)
+    count = Swift.min(count, c13.count)
+    count = Swift.min(count, c14.count)
 
     if count == 0 {
         return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWith+Arity2.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWith+Arity2.swift
@@ -17,10 +17,8 @@ public func differentiableZipWith<C1, C2, Result>(
     C2.Element: Differentiable,
     Result: Differentiable
 {
-    let capacity = min(
-        c1.count,
-        c2.count
-    )
+    var capacity = c1.count
+    capacity = Swift.min(capacity, c2.count)
 
     if capacity == 0 { return [] }
 
@@ -64,10 +62,8 @@ public func _vjpDifferentiableZipWith<C1, C2, Result>(
     C2.Element: Differentiable,
     Result: Differentiable
 {
-    let count = min(
-        c1.count,
-        c2.count
-    )
+    var count = c1.count
+    count = Swift.min(count, c2.count)
 
     if count == 0 {
         return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWith+Arity3.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWith+Arity3.swift
@@ -21,11 +21,9 @@ public func differentiableZipWith<C1, C2, C3, Result>(
     C3.Element: Differentiable,
     Result: Differentiable
 {
-    let capacity = min(
-        c1.count,
-        c2.count,
-        c3.count
-    )
+    var capacity = c1.count
+    capacity = Swift.min(capacity, c2.count)
+    capacity = Swift.min(capacity, c3.count)
 
     if capacity == 0 { return [] }
 
@@ -77,11 +75,9 @@ public func _vjpDifferentiableZipWith<C1, C2, C3, Result>(
     C3.Element: Differentiable,
     Result: Differentiable
 {
-    let count = min(
-        c1.count,
-        c2.count,
-        c3.count
-    )
+    var count = c1.count
+    count = Swift.min(count, c2.count)
+    count = Swift.min(count, c3.count)
 
     if count == 0 {
         return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWith+Arity4.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWith+Arity4.swift
@@ -25,12 +25,10 @@ public func differentiableZipWith<C1, C2, C3, C4, Result>(
     C4.Element: Differentiable,
     Result: Differentiable
 {
-    let capacity = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count
-    )
+    var capacity = c1.count
+    capacity = Swift.min(capacity, c2.count)
+    capacity = Swift.min(capacity, c3.count)
+    capacity = Swift.min(capacity, c4.count)
 
     if capacity == 0 { return [] }
 
@@ -90,12 +88,10 @@ public func _vjpDifferentiableZipWith<C1, C2, C3, C4, Result>(
     C4.Element: Differentiable,
     Result: Differentiable
 {
-    let count = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count
-    )
+    var count = c1.count
+    count = Swift.min(count, c2.count)
+    count = Swift.min(count, c3.count)
+    count = Swift.min(count, c4.count)
 
     if count == 0 {
         return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWith+Arity5.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWith+Arity5.swift
@@ -29,13 +29,11 @@ public func differentiableZipWith<C1, C2, C3, C4, C5, Result>(
     C5.Element: Differentiable,
     Result: Differentiable
 {
-    let capacity = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count
-    )
+    var capacity = c1.count
+    capacity = Swift.min(capacity, c2.count)
+    capacity = Swift.min(capacity, c3.count)
+    capacity = Swift.min(capacity, c4.count)
+    capacity = Swift.min(capacity, c5.count)
 
     if capacity == 0 { return [] }
 
@@ -103,13 +101,11 @@ public func _vjpDifferentiableZipWith<C1, C2, C3, C4, C5, Result>(
     C5.Element: Differentiable,
     Result: Differentiable
 {
-    let count = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count
-    )
+    var count = c1.count
+    count = Swift.min(count, c2.count)
+    count = Swift.min(count, c3.count)
+    count = Swift.min(count, c4.count)
+    count = Swift.min(count, c5.count)
 
     if count == 0 {
         return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWith+Arity6.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWith+Arity6.swift
@@ -33,14 +33,12 @@ public func differentiableZipWith<C1, C2, C3, C4, C5, C6, Result>(
     C6.Element: Differentiable,
     Result: Differentiable
 {
-    let capacity = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count
-    )
+    var capacity = c1.count
+    capacity = Swift.min(capacity, c2.count)
+    capacity = Swift.min(capacity, c3.count)
+    capacity = Swift.min(capacity, c4.count)
+    capacity = Swift.min(capacity, c5.count)
+    capacity = Swift.min(capacity, c6.count)
 
     if capacity == 0 { return [] }
 
@@ -116,14 +114,12 @@ public func _vjpDifferentiableZipWith<C1, C2, C3, C4, C5, C6, Result>(
     C6.Element: Differentiable,
     Result: Differentiable
 {
-    let count = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count
-    )
+    var count = c1.count
+    count = Swift.min(count, c2.count)
+    count = Swift.min(count, c3.count)
+    count = Swift.min(count, c4.count)
+    count = Swift.min(count, c5.count)
+    count = Swift.min(count, c6.count)
 
     if count == 0 {
         return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWith+Arity7.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWith+Arity7.swift
@@ -37,15 +37,13 @@ public func differentiableZipWith<C1, C2, C3, C4, C5, C6, C7, Result>(
     C7.Element: Differentiable,
     Result: Differentiable
 {
-    let capacity = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count
-    )
+    var capacity = c1.count
+    capacity = Swift.min(capacity, c2.count)
+    capacity = Swift.min(capacity, c3.count)
+    capacity = Swift.min(capacity, c4.count)
+    capacity = Swift.min(capacity, c5.count)
+    capacity = Swift.min(capacity, c6.count)
+    capacity = Swift.min(capacity, c7.count)
 
     if capacity == 0 { return [] }
 
@@ -129,15 +127,13 @@ public func _vjpDifferentiableZipWith<C1, C2, C3, C4, C5, C6, C7, Result>(
     C7.Element: Differentiable,
     Result: Differentiable
 {
-    let count = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count
-    )
+    var count = c1.count
+    count = Swift.min(count, c2.count)
+    count = Swift.min(count, c3.count)
+    count = Swift.min(count, c4.count)
+    count = Swift.min(count, c5.count)
+    count = Swift.min(count, c6.count)
+    count = Swift.min(count, c7.count)
 
     if count == 0 {
         return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWith+Arity8.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWith+Arity8.swift
@@ -41,16 +41,14 @@ public func differentiableZipWith<C1, C2, C3, C4, C5, C6, C7, C8, Result>(
     C8.Element: Differentiable,
     Result: Differentiable
 {
-    let capacity = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count
-    )
+    var capacity = c1.count
+    capacity = Swift.min(capacity, c2.count)
+    capacity = Swift.min(capacity, c3.count)
+    capacity = Swift.min(capacity, c4.count)
+    capacity = Swift.min(capacity, c5.count)
+    capacity = Swift.min(capacity, c6.count)
+    capacity = Swift.min(capacity, c7.count)
+    capacity = Swift.min(capacity, c8.count)
 
     if capacity == 0 { return [] }
 
@@ -142,16 +140,14 @@ public func _vjpDifferentiableZipWith<C1, C2, C3, C4, C5, C6, C7, C8, Result>(
     C8.Element: Differentiable,
     Result: Differentiable
 {
-    let count = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count
-    )
+    var count = c1.count
+    count = Swift.min(count, c2.count)
+    count = Swift.min(count, c3.count)
+    count = Swift.min(count, c4.count)
+    count = Swift.min(count, c5.count)
+    count = Swift.min(count, c6.count)
+    count = Swift.min(count, c7.count)
+    count = Swift.min(count, c8.count)
 
     if count == 0 {
         return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWith+Arity9.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWith+Arity9.swift
@@ -45,17 +45,15 @@ public func differentiableZipWith<C1, C2, C3, C4, C5, C6, C7, C8, C9, Result>(
     C9.Element: Differentiable,
     Result: Differentiable
 {
-    let capacity = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count,
-        c9.count
-    )
+    var capacity = c1.count
+    capacity = Swift.min(capacity, c2.count)
+    capacity = Swift.min(capacity, c3.count)
+    capacity = Swift.min(capacity, c4.count)
+    capacity = Swift.min(capacity, c5.count)
+    capacity = Swift.min(capacity, c6.count)
+    capacity = Swift.min(capacity, c7.count)
+    capacity = Swift.min(capacity, c8.count)
+    capacity = Swift.min(capacity, c9.count)
 
     if capacity == 0 { return [] }
 
@@ -155,17 +153,15 @@ public func _vjpDifferentiableZipWith<C1, C2, C3, C4, C5, C6, C7, C8, C9, Result
     C9.Element: Differentiable,
     Result: Differentiable
 {
-    let count = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count,
-        c9.count
-    )
+    var count = c1.count
+    count = Swift.min(count, c2.count)
+    count = Swift.min(count, c3.count)
+    count = Swift.min(count, c4.count)
+    count = Swift.min(count, c5.count)
+    count = Swift.min(count, c6.count)
+    count = Swift.min(count, c7.count)
+    count = Swift.min(count, c8.count)
+    count = Swift.min(count, c9.count)
 
     if count == 0 {
         return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity10.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity10.swift
@@ -49,18 +49,16 @@ public func differentiableZipWith<Inout, C2, C3, C4, C5, C6, C7, C8, C9, C10>(
     C10: DifferentiableCollection,
     C10.Element: Differentiable
 {
-    let capacity = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count,
-        c9.count,
-        c10.count
-    )
+    var capacity = c1.count
+    capacity = Swift.min(capacity, c2.count)
+    capacity = Swift.min(capacity, c3.count)
+    capacity = Swift.min(capacity, c4.count)
+    capacity = Swift.min(capacity, c5.count)
+    capacity = Swift.min(capacity, c6.count)
+    capacity = Swift.min(capacity, c7.count)
+    capacity = Swift.min(capacity, c8.count)
+    capacity = Swift.min(capacity, c9.count)
+    capacity = Swift.min(capacity, c10.count)
 
     if capacity == 0 { return }
 
@@ -163,18 +161,16 @@ public func _vjpDifferentiableZipWith<Inout, C2, C3, C4, C5, C6, C7, C8, C9, C10
     C10: DifferentiableCollection,
     C10.Element: Differentiable
 {
-    let count = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count,
-        c9.count,
-        c10.count
-    )
+    var count = c1.count
+    count = Swift.min(count, c2.count)
+    count = Swift.min(count, c3.count)
+    count = Swift.min(count, c4.count)
+    count = Swift.min(count, c5.count)
+    count = Swift.min(count, c6.count)
+    count = Swift.min(count, c7.count)
+    count = Swift.min(count, c8.count)
+    count = Swift.min(count, c9.count)
+    count = Swift.min(count, c10.count)
 
     if count == 0 {
         return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity11.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity11.swift
@@ -53,19 +53,17 @@ public func differentiableZipWith<Inout, C2, C3, C4, C5, C6, C7, C8, C9, C10, C1
     C11: DifferentiableCollection,
     C11.Element: Differentiable
 {
-    let capacity = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count,
-        c9.count,
-        c10.count,
-        c11.count
-    )
+    var capacity = c1.count
+    capacity = Swift.min(capacity, c2.count)
+    capacity = Swift.min(capacity, c3.count)
+    capacity = Swift.min(capacity, c4.count)
+    capacity = Swift.min(capacity, c5.count)
+    capacity = Swift.min(capacity, c6.count)
+    capacity = Swift.min(capacity, c7.count)
+    capacity = Swift.min(capacity, c8.count)
+    capacity = Swift.min(capacity, c9.count)
+    capacity = Swift.min(capacity, c10.count)
+    capacity = Swift.min(capacity, c11.count)
 
     if capacity == 0 { return }
 
@@ -176,19 +174,17 @@ public func _vjpDifferentiableZipWith<Inout, C2, C3, C4, C5, C6, C7, C8, C9, C10
     C11: DifferentiableCollection,
     C11.Element: Differentiable
 {
-    let count = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count,
-        c9.count,
-        c10.count,
-        c11.count
-    )
+    var count = c1.count
+    count = Swift.min(count, c2.count)
+    count = Swift.min(count, c3.count)
+    count = Swift.min(count, c4.count)
+    count = Swift.min(count, c5.count)
+    count = Swift.min(count, c6.count)
+    count = Swift.min(count, c7.count)
+    count = Swift.min(count, c8.count)
+    count = Swift.min(count, c9.count)
+    count = Swift.min(count, c10.count)
+    count = Swift.min(count, c11.count)
 
     if count == 0 {
         return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity12.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity12.swift
@@ -57,20 +57,18 @@ public func differentiableZipWith<Inout, C2, C3, C4, C5, C6, C7, C8, C9, C10, C1
     C12: DifferentiableCollection,
     C12.Element: Differentiable
 {
-    let capacity = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count,
-        c9.count,
-        c10.count,
-        c11.count,
-        c12.count
-    )
+    var capacity = c1.count
+    capacity = Swift.min(capacity, c2.count)
+    capacity = Swift.min(capacity, c3.count)
+    capacity = Swift.min(capacity, c4.count)
+    capacity = Swift.min(capacity, c5.count)
+    capacity = Swift.min(capacity, c6.count)
+    capacity = Swift.min(capacity, c7.count)
+    capacity = Swift.min(capacity, c8.count)
+    capacity = Swift.min(capacity, c9.count)
+    capacity = Swift.min(capacity, c10.count)
+    capacity = Swift.min(capacity, c11.count)
+    capacity = Swift.min(capacity, c12.count)
 
     if capacity == 0 { return }
 
@@ -189,20 +187,18 @@ public func _vjpDifferentiableZipWith<Inout, C2, C3, C4, C5, C6, C7, C8, C9, C10
     C12: DifferentiableCollection,
     C12.Element: Differentiable
 {
-    let count = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count,
-        c9.count,
-        c10.count,
-        c11.count,
-        c12.count
-    )
+    var count = c1.count
+    count = Swift.min(count, c2.count)
+    count = Swift.min(count, c3.count)
+    count = Swift.min(count, c4.count)
+    count = Swift.min(count, c5.count)
+    count = Swift.min(count, c6.count)
+    count = Swift.min(count, c7.count)
+    count = Swift.min(count, c8.count)
+    count = Swift.min(count, c9.count)
+    count = Swift.min(count, c10.count)
+    count = Swift.min(count, c11.count)
+    count = Swift.min(count, c12.count)
 
     if count == 0 {
         return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity13.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity13.swift
@@ -61,21 +61,19 @@ public func differentiableZipWith<Inout, C2, C3, C4, C5, C6, C7, C8, C9, C10, C1
     C13: DifferentiableCollection,
     C13.Element: Differentiable
 {
-    let capacity = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count,
-        c9.count,
-        c10.count,
-        c11.count,
-        c12.count,
-        c13.count
-    )
+    var capacity = c1.count
+    capacity = Swift.min(capacity, c2.count)
+    capacity = Swift.min(capacity, c3.count)
+    capacity = Swift.min(capacity, c4.count)
+    capacity = Swift.min(capacity, c5.count)
+    capacity = Swift.min(capacity, c6.count)
+    capacity = Swift.min(capacity, c7.count)
+    capacity = Swift.min(capacity, c8.count)
+    capacity = Swift.min(capacity, c9.count)
+    capacity = Swift.min(capacity, c10.count)
+    capacity = Swift.min(capacity, c11.count)
+    capacity = Swift.min(capacity, c12.count)
+    capacity = Swift.min(capacity, c13.count)
 
     if capacity == 0 { return }
 
@@ -202,21 +200,19 @@ public func _vjpDifferentiableZipWith<Inout, C2, C3, C4, C5, C6, C7, C8, C9, C10
     C13: DifferentiableCollection,
     C13.Element: Differentiable
 {
-    let count = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count,
-        c9.count,
-        c10.count,
-        c11.count,
-        c12.count,
-        c13.count
-    )
+    var count = c1.count
+    count = Swift.min(count, c2.count)
+    count = Swift.min(count, c3.count)
+    count = Swift.min(count, c4.count)
+    count = Swift.min(count, c5.count)
+    count = Swift.min(count, c6.count)
+    count = Swift.min(count, c7.count)
+    count = Swift.min(count, c8.count)
+    count = Swift.min(count, c9.count)
+    count = Swift.min(count, c10.count)
+    count = Swift.min(count, c11.count)
+    count = Swift.min(count, c12.count)
+    count = Swift.min(count, c13.count)
 
     if count == 0 {
         return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity14.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity14.swift
@@ -65,22 +65,20 @@ public func differentiableZipWith<Inout, C2, C3, C4, C5, C6, C7, C8, C9, C10, C1
     C14: DifferentiableCollection,
     C14.Element: Differentiable
 {
-    let capacity = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count,
-        c9.count,
-        c10.count,
-        c11.count,
-        c12.count,
-        c13.count,
-        c14.count
-    )
+    var capacity = c1.count
+    capacity = Swift.min(capacity, c2.count)
+    capacity = Swift.min(capacity, c3.count)
+    capacity = Swift.min(capacity, c4.count)
+    capacity = Swift.min(capacity, c5.count)
+    capacity = Swift.min(capacity, c6.count)
+    capacity = Swift.min(capacity, c7.count)
+    capacity = Swift.min(capacity, c8.count)
+    capacity = Swift.min(capacity, c9.count)
+    capacity = Swift.min(capacity, c10.count)
+    capacity = Swift.min(capacity, c11.count)
+    capacity = Swift.min(capacity, c12.count)
+    capacity = Swift.min(capacity, c13.count)
+    capacity = Swift.min(capacity, c14.count)
 
     if capacity == 0 { return }
 
@@ -215,22 +213,20 @@ public func _vjpDifferentiableZipWith<Inout, C2, C3, C4, C5, C6, C7, C8, C9, C10
     C14: DifferentiableCollection,
     C14.Element: Differentiable
 {
-    let count = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count,
-        c9.count,
-        c10.count,
-        c11.count,
-        c12.count,
-        c13.count,
-        c14.count
-    )
+    var count = c1.count
+    count = Swift.min(count, c2.count)
+    count = Swift.min(count, c3.count)
+    count = Swift.min(count, c4.count)
+    count = Swift.min(count, c5.count)
+    count = Swift.min(count, c6.count)
+    count = Swift.min(count, c7.count)
+    count = Swift.min(count, c8.count)
+    count = Swift.min(count, c9.count)
+    count = Swift.min(count, c10.count)
+    count = Swift.min(count, c11.count)
+    count = Swift.min(count, c12.count)
+    count = Swift.min(count, c13.count)
+    count = Swift.min(count, c14.count)
 
     if count == 0 {
         return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity2.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity2.swift
@@ -17,10 +17,8 @@ public func differentiableZipWith<Inout, C2>(
     C2: DifferentiableCollection,
     C2.Element: Differentiable
 {
-    let capacity = min(
-        c1.count,
-        c2.count
-    )
+    var capacity = c1.count
+    capacity = Swift.min(capacity, c2.count)
 
     if capacity == 0 { return }
 
@@ -59,10 +57,8 @@ public func _vjpDifferentiableZipWith<Inout, C2>(
     C2: DifferentiableCollection,
     C2.Element: Differentiable
 {
-    let count = min(
-        c1.count,
-        c2.count
-    )
+    var count = c1.count
+    count = Swift.min(count, c2.count)
 
     if count == 0 {
         return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity3.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity3.swift
@@ -21,11 +21,9 @@ public func differentiableZipWith<Inout, C2, C3>(
     C3: DifferentiableCollection,
     C3.Element: Differentiable
 {
-    let capacity = min(
-        c1.count,
-        c2.count,
-        c3.count
-    )
+    var capacity = c1.count
+    capacity = Swift.min(capacity, c2.count)
+    capacity = Swift.min(capacity, c3.count)
 
     if capacity == 0 { return }
 
@@ -72,11 +70,9 @@ public func _vjpDifferentiableZipWith<Inout, C2, C3>(
     C3: DifferentiableCollection,
     C3.Element: Differentiable
 {
-    let count = min(
-        c1.count,
-        c2.count,
-        c3.count
-    )
+    var count = c1.count
+    count = Swift.min(count, c2.count)
+    count = Swift.min(count, c3.count)
 
     if count == 0 {
         return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity4.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity4.swift
@@ -25,12 +25,10 @@ public func differentiableZipWith<Inout, C2, C3, C4>(
     C4: DifferentiableCollection,
     C4.Element: Differentiable
 {
-    let capacity = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count
-    )
+    var capacity = c1.count
+    capacity = Swift.min(capacity, c2.count)
+    capacity = Swift.min(capacity, c3.count)
+    capacity = Swift.min(capacity, c4.count)
 
     if capacity == 0 { return }
 
@@ -85,12 +83,10 @@ public func _vjpDifferentiableZipWith<Inout, C2, C3, C4>(
     C4: DifferentiableCollection,
     C4.Element: Differentiable
 {
-    let count = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count
-    )
+    var count = c1.count
+    count = Swift.min(count, c2.count)
+    count = Swift.min(count, c3.count)
+    count = Swift.min(count, c4.count)
 
     if count == 0 {
         return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity5.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity5.swift
@@ -29,13 +29,11 @@ public func differentiableZipWith<Inout, C2, C3, C4, C5>(
     C5: DifferentiableCollection,
     C5.Element: Differentiable
 {
-    let capacity = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count
-    )
+    var capacity = c1.count
+    capacity = Swift.min(capacity, c2.count)
+    capacity = Swift.min(capacity, c3.count)
+    capacity = Swift.min(capacity, c4.count)
+    capacity = Swift.min(capacity, c5.count)
 
     if capacity == 0 { return }
 
@@ -98,13 +96,11 @@ public func _vjpDifferentiableZipWith<Inout, C2, C3, C4, C5>(
     C5: DifferentiableCollection,
     C5.Element: Differentiable
 {
-    let count = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count
-    )
+    var count = c1.count
+    count = Swift.min(count, c2.count)
+    count = Swift.min(count, c3.count)
+    count = Swift.min(count, c4.count)
+    count = Swift.min(count, c5.count)
 
     if count == 0 {
         return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity6.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity6.swift
@@ -33,14 +33,12 @@ public func differentiableZipWith<Inout, C2, C3, C4, C5, C6>(
     C6: DifferentiableCollection,
     C6.Element: Differentiable
 {
-    let capacity = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count
-    )
+    var capacity = c1.count
+    capacity = Swift.min(capacity, c2.count)
+    capacity = Swift.min(capacity, c3.count)
+    capacity = Swift.min(capacity, c4.count)
+    capacity = Swift.min(capacity, c5.count)
+    capacity = Swift.min(capacity, c6.count)
 
     if capacity == 0 { return }
 
@@ -111,14 +109,12 @@ public func _vjpDifferentiableZipWith<Inout, C2, C3, C4, C5, C6>(
     C6: DifferentiableCollection,
     C6.Element: Differentiable
 {
-    let count = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count
-    )
+    var count = c1.count
+    count = Swift.min(count, c2.count)
+    count = Swift.min(count, c3.count)
+    count = Swift.min(count, c4.count)
+    count = Swift.min(count, c5.count)
+    count = Swift.min(count, c6.count)
 
     if count == 0 {
         return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity7.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity7.swift
@@ -37,15 +37,13 @@ public func differentiableZipWith<Inout, C2, C3, C4, C5, C6, C7>(
     C7: DifferentiableCollection,
     C7.Element: Differentiable
 {
-    let capacity = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count
-    )
+    var capacity = c1.count
+    capacity = Swift.min(capacity, c2.count)
+    capacity = Swift.min(capacity, c3.count)
+    capacity = Swift.min(capacity, c4.count)
+    capacity = Swift.min(capacity, c5.count)
+    capacity = Swift.min(capacity, c6.count)
+    capacity = Swift.min(capacity, c7.count)
 
     if capacity == 0 { return }
 
@@ -124,15 +122,13 @@ public func _vjpDifferentiableZipWith<Inout, C2, C3, C4, C5, C6, C7>(
     C7: DifferentiableCollection,
     C7.Element: Differentiable
 {
-    let count = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count
-    )
+    var count = c1.count
+    count = Swift.min(count, c2.count)
+    count = Swift.min(count, c3.count)
+    count = Swift.min(count, c4.count)
+    count = Swift.min(count, c5.count)
+    count = Swift.min(count, c6.count)
+    count = Swift.min(count, c7.count)
 
     if count == 0 {
         return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity8.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity8.swift
@@ -41,16 +41,14 @@ public func differentiableZipWith<Inout, C2, C3, C4, C5, C6, C7, C8>(
     C8: DifferentiableCollection,
     C8.Element: Differentiable
 {
-    let capacity = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count
-    )
+    var capacity = c1.count
+    capacity = Swift.min(capacity, c2.count)
+    capacity = Swift.min(capacity, c3.count)
+    capacity = Swift.min(capacity, c4.count)
+    capacity = Swift.min(capacity, c5.count)
+    capacity = Swift.min(capacity, c6.count)
+    capacity = Swift.min(capacity, c7.count)
+    capacity = Swift.min(capacity, c8.count)
 
     if capacity == 0 { return }
 
@@ -137,16 +135,14 @@ public func _vjpDifferentiableZipWith<Inout, C2, C3, C4, C5, C6, C7, C8>(
     C8: DifferentiableCollection,
     C8.Element: Differentiable
 {
-    let count = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count
-    )
+    var count = c1.count
+    count = Swift.min(count, c2.count)
+    count = Swift.min(count, c3.count)
+    count = Swift.min(count, c4.count)
+    count = Swift.min(count, c5.count)
+    count = Swift.min(count, c6.count)
+    count = Swift.min(count, c7.count)
+    count = Swift.min(count, c8.count)
 
     if count == 0 {
         return (

--- a/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity9.swift
+++ b/Sources/Differentiation/DifferentiableZip/ZipWithInout+Arity9.swift
@@ -45,17 +45,15 @@ public func differentiableZipWith<Inout, C2, C3, C4, C5, C6, C7, C8, C9>(
     C9: DifferentiableCollection,
     C9.Element: Differentiable
 {
-    let capacity = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count,
-        c9.count
-    )
+    var capacity = c1.count
+    capacity = Swift.min(capacity, c2.count)
+    capacity = Swift.min(capacity, c3.count)
+    capacity = Swift.min(capacity, c4.count)
+    capacity = Swift.min(capacity, c5.count)
+    capacity = Swift.min(capacity, c6.count)
+    capacity = Swift.min(capacity, c7.count)
+    capacity = Swift.min(capacity, c8.count)
+    capacity = Swift.min(capacity, c9.count)
 
     if capacity == 0 { return }
 
@@ -150,17 +148,15 @@ public func _vjpDifferentiableZipWith<Inout, C2, C3, C4, C5, C6, C7, C8, C9>(
     C9: DifferentiableCollection,
     C9.Element: Differentiable
 {
-    let count = min(
-        c1.count,
-        c2.count,
-        c3.count,
-        c4.count,
-        c5.count,
-        c6.count,
-        c7.count,
-        c8.count,
-        c9.count
-    )
+    var count = c1.count
+    count = Swift.min(count, c2.count)
+    count = Swift.min(count, c3.count)
+    count = Swift.min(count, c4.count)
+    count = Swift.min(count, c5.count)
+    count = Swift.min(count, c6.count)
+    count = Swift.min(count, c7.count)
+    count = Swift.min(count, c8.count)
+    count = Swift.min(count, c9.count)
 
     if count == 0 {
         return (


### PR DESCRIPTION
The type checker seems to struggle more and more as the number of arguments grows in a single expression. The pattern that slows things down is `min(count, count, count, ...)`. Each arity that we support worsens the problem, with Arity14 taking tens of seconds to compile.

While it is a bit more verbose, switching to an approach that breaks this single complex expression up into many simpler expressions relieves the type checking burden pretty considerably. So the new pattern establishes an initial result, and because `min()` is associative, we can take the min of result and each collection, which is much easier for the type checker.

These stats are just from my local build...
  - Clean builds went from ~65s -> ~14s, ~78% reduction
  - Incremental builds went from ~56s -> ~5s, ~91% reduction