### PR TITLE
feat: move code generator for simd stdlib overloads from swift-numerics-differentiable to swift-differentiation

### DIFF
--- a/SIMDSTDLibOverloadsCodeGenerator/.gitignore
+++ b/SIMDSTDLibOverloadsCodeGenerator/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/SIMDSTDLibOverloadsCodeGenerator/Package.swift
+++ b/SIMDSTDLibOverloadsCodeGenerator/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 6.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "SIMDSTDLibCodeGenerator",
+    platforms: [
+        .macOS(.v13),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .executableTarget(
+            name: "SIMDSTDLibCodeGenerator"
+        ),
+    ]
+)

--- a/SIMDSTDLibOverloadsCodeGenerator/README.md
+++ b/SIMDSTDLibOverloadsCodeGenerator/README.md
@@ -1,0 +1,7 @@
+# SIMDSTDLibCodeGenerator
+
+run the following to generate `SIMD`protocol overloads for all SIMD types. This is a workaround to the compiler currently not picking up the derivatives defined for methods defined on the `SIMD` protocol. `+,-,\*,/` etc.
+
+```
+swift run SIMDSTDLibCodeGenerator ../Sources/Differentiation/SIMDSTDLibOverloads/
+```

--- a/SIMDSTDlibOverloadsCodeGenerator/Sources/SIMDSTDLibCodeGenerator/CodeGenerator.swift
+++ b/SIMDSTDlibOverloadsCodeGenerator/Sources/SIMDSTDLibCodeGenerator/CodeGenerator.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+@main
+struct CodeGenerator {
+    static func main() throws {
+        guard CommandLine.arguments.count == 2 else {
+            print("expected usage: CodeGenerator <output-directory>")
+            throw CodeGeneratorError.invalidArguments
+        }
+        // arguments[0] is the path to this command line tool
+        let output = URL(filePath: CommandLine.arguments[1])
+
+        let simdWidths = [2, 3, 4, 8, 16, 32, 64]
+        let floatingPointTypes = ["Float", "Double"]
+
+        for simdWidth in simdWidths {
+            for floatingPointType in floatingPointTypes {
+                let simdOverloadsFileURL = output.appending(component: "SIMD\(simdWidth)+\(floatingPointType)STDLibOverloads.swift")
+                let simdOverloadsCode = STDLibOverloadsGenerator.generateFor(floatingPointType: floatingPointType, simdWidth: simdWidth)
+                try simdOverloadsCode.write(to: simdOverloadsFileURL, atomically: true, encoding: .utf8)
+            }
+        }
+    }
+}
+
+enum CodeGeneratorError: Error {
+    case invalidArguments
+}

--- a/SIMDSTDlibOverloadsCodeGenerator/Sources/SIMDSTDLibCodeGenerator/STDLibOverloadsGenerator.swift
+++ b/SIMDSTDlibOverloadsCodeGenerator/Sources/SIMDSTDLibCodeGenerator/STDLibOverloadsGenerator.swift
@@ -1,0 +1,334 @@
+enum STDLibOverloadsGenerator {
+    static func generateFor(floatingPointType: String, simdWidth: Int) -> String {
+        """
+        import _Differentiation
+
+        extension SIMD\(simdWidth) where Scalar == \(floatingPointType) {
+            @_transparent
+            public static func + (a: Self, b: Self) -> Self {
+                var result = Self()
+                for i in result.indices { result[i] = a[i] + b[i] }
+                return result
+            }
+
+            @_transparent
+            @derivative(of: +)
+            public static func _vjpPlus(a: Self, b: Self) -> (
+                value: Self,
+                pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+            ) {
+                (
+                    value: a + b,
+                    pullback: { v in
+                        (v, v)
+                    }
+                )
+            }
+
+            @_transparent
+            public static func - (a: Self, b: Self) -> Self {
+                var result = Self()
+                for i in result.indices { result[i] = a[i] - b[i] }
+                return result
+            }
+
+            @_transparent
+            @derivative(of: -)
+            public static func _vjpMin(a: Self, b: Self) -> (
+                value: Self,
+                pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+            ) {
+                (
+                    value: a - b,
+                    pullback: { v in
+                        (v, -v)
+                    }
+                )
+            }
+
+            @_transparent
+            public static func * (a: Self, b: Self) -> Self {
+                var result = Self()
+                for i in result.indices { result[i] = a[i] * b[i] }
+                return result
+            }
+
+            @inlinable
+            @derivative(of: *)
+            static func _vjpMultiply(a: Self, b: Self) -> (
+                value: Self,
+                pullback: (TangentVector) -> (TangentVector, TangentVector)
+            ) {
+                (a * b, { v in
+                    (v * b, v * a)
+                })
+            }
+
+            @_transparent
+            public static func / (a: Self, b: Self) -> Self {
+                var result = Self()
+                for i in result.indices { result[i] = a[i] / b[i] }
+                return result
+            }
+
+            @inlinable
+            @derivative(of: /)
+            static func _vjpDivide(lhs: Self, rhs: Self) -> (
+                value: Self,
+                pullback: (TangentVector) -> (TangentVector, TangentVector)
+            ) {
+                (lhs / rhs, { v in
+                    (v / rhs, -lhs / (rhs * rhs) * v)
+                })
+            }
+
+            @_transparent
+            public func addingProduct(_ a: Self, _ b: Self) -> Self {
+                var result = Self()
+                for i in result.indices { result[i] = self[i].addingProduct(a[i], b[i]) }
+                return result
+            }
+
+            @derivative(of: addingProduct)
+            @_transparent
+            public func _vjpAddingProduct(
+                _ lhs: Self, _ rhs: Self
+            ) -> (value: Self, pullback: (Self) -> (Self, Self, Self)) {
+                (addingProduct(lhs, rhs), { v in (v, v * rhs, v * lhs) })
+            }
+
+            @_transparent
+            public func squareRoot() -> Self {
+                var result = Self()
+                for i in result.indices { result[i] = self[i].squareRoot() }
+                return result
+            }
+
+            @_transparent
+            public func _vjpSquareRoot() -> (value: Self, pullback: (TangentVector) -> TangentVector) {
+                let y = self.squareRoot()
+                return (y, { v in v / (2 * y) })
+            }
+
+            /// The sum of the scalars in the vector.
+            @_alwaysEmitIntoClient
+            public func sum() -> Scalar {
+                // Implementation note: this eventually be defined to lower to either
+                // llvm.experimental.vector.reduce.fadd or an explicit tree-sum. Open-
+                // coding the tree sum is problematic, we probably need to define a
+                // Swift Builtin to support it.
+                //
+                // Use -0 so that LLVM can optimize away initial value + self[0].
+                var result = -Scalar.zero
+                for i in indices {
+                    result += self[i]
+                }
+                return result
+            }
+
+            @inlinable
+            @_alwaysEmitIntoClient
+            @derivative(of: sum)
+            func _vjpSum() -> (
+                value: Scalar,
+                pullback: (Scalar.TangentVector) -> TangentVector
+            ) {
+                (sum(), { v in Self(repeating: Scalar(v)) })
+            }
+
+            @_transparent
+            public static prefix func - (a: Self) -> Self {
+                0 - a
+            }
+
+            @inlinable
+            @derivative(of: -)
+            static func _vjpNegate(a: Self) -> (
+                value: Self,
+                pullback: (TangentVector) -> (TangentVector)
+            ) {
+                (-a, { v in
+                    -v
+                })
+            }
+
+            @_transparent
+            public static func + (a: Scalar, b: Self) -> Self {
+                Self(repeating: a) + b
+            }
+
+            @inlinable
+            @derivative(of: +)
+            static func _vjpAdd(a: Scalar, b: Self) -> (
+                value: Self,
+                pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+            ) {
+                (a + b, { v in
+                    (v.sum(), v)
+                })
+            }
+
+            @_transparent
+            public static func - (a: Scalar, b: Self) -> Self {
+                Self(repeating: a) - b
+            }
+
+            @inlinable
+            @derivative(of: -)
+            static func _vjpSubtract(a: Scalar, b: Self) -> (
+                value: Self,
+                pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+            ) {
+                (a - b, { v in
+                    (v.sum(), -v)
+                })
+            }
+
+            @_transparent
+            public static func * (a: Scalar, b: Self) -> Self {
+                Self(repeating: a) * b
+            }
+
+            @inlinable
+            @derivative(of: *)
+            static func _vjpMultiply(lhs: Scalar, rhs: Self) -> (
+                value: Self,
+                pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+            ) {
+                (lhs * rhs, { v in
+                    ((v * rhs).sum(), v * lhs)
+                })
+            }
+
+            @_transparent
+            public static func / (a: Scalar, b: Self) -> Self {
+                Self(repeating: a) / b
+            }
+
+            @inlinable
+            @derivative(of: /)
+            static func _vjpDivide(lhs: Scalar, rhs: Self) -> (
+                value: Self,
+                pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+            ) {
+                (lhs / rhs, { v in
+                    ((v / rhs).sum(), -lhs / (rhs * rhs) * v)
+                })
+            }
+
+            @_transparent
+            public static func + (a: Self, b: Scalar) -> Self {
+                a + Self(repeating: b)
+            }
+
+            @inlinable
+            @derivative(of: +)
+            static func _vjpAdd(lhs: Self, rhs: Scalar) -> (
+                value: Self,
+                pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+            ) {
+                (lhs + rhs, { v in
+                    (v, v.sum())
+                })
+            }
+
+            @_transparent
+            public static func - (a: Self, b: Scalar) -> Self {
+                a - Self(repeating: b)
+            }
+
+            @inlinable
+            @derivative(of: -)
+            static func _vjpSubtract(lhs: Self, rhs: Scalar) -> (
+                value: Self,
+                pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+            ) {
+                (lhs - rhs, { v in
+                    (v, -v.sum())
+                })
+            }
+
+            @_transparent
+            public static func * (a: Self, b: Scalar) -> Self {
+                a * Self(repeating: b)
+            }
+
+            @inlinable
+            @derivative(of: *)
+            static func _vjpMultiply(lhs: Self, rhs: Scalar) -> (
+                value: Self,
+                pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+            ) {
+                (lhs * rhs, { v in
+                    (v * rhs, (v * lhs).sum())
+                })
+            }
+
+            @_transparent
+            public static func / (a: Self, b: Scalar) -> Self {
+                a / Self(repeating: b)
+            }
+
+            @inlinable
+            @derivative(of: /)
+            static func _vjpDivide(lhs: Self, rhs: Scalar) -> (
+                value: Self,
+                pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+            ) {
+                (lhs / rhs, { v in
+                    (v / rhs, (-lhs / (rhs * rhs) * v).sum())
+                })
+            }
+
+            @differentiable(reverse)
+            @_transparent
+            public static func += (a: inout Self, b: Self) {
+                a = a + b
+            }
+
+            @differentiable(reverse)
+            @_transparent
+            public static func -= (a: inout Self, b: Self) {
+                a = a - b
+            }
+
+            @differentiable(reverse)
+            @_transparent
+            public static func *= (a: inout Self, b: Self) {
+                a = a * b
+            }
+
+            @differentiable(reverse)
+            @_transparent
+            public static func /= (a: inout Self, b: Self) {
+                a = a / b
+            }
+
+            @differentiable(reverse)
+            @_transparent
+            public static func += (a: inout Self, b: Scalar) {
+                a = a + b
+            }
+
+            @differentiable(reverse)
+            @_transparent
+            public static func -= (a: inout Self, b: Scalar) {
+                a = a - b
+            }
+
+            @differentiable(reverse)
+            @_transparent
+            public static func *= (a: inout Self, b: Scalar) {
+                a = a * b
+            }
+
+            @differentiable(reverse)
+            @_transparent
+            public static func /= (a: inout Self, b: Scalar) {
+                a = a / b
+            }
+        }
+
+        """
+    }
+}

--- a/Sources/Differentiation/SIMDSTDLibOverloads/SIMD16+DoubleSTDLibOverloads.swift
+++ b/Sources/Differentiation/SIMDSTDLibOverloads/SIMD16+DoubleSTDLibOverloads.swift
@@ -1,0 +1,327 @@
+import _Differentiation
+
+extension SIMD16 where Scalar == Double {
+    @_transparent
+    public static func + (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] + b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: +)
+    public static func _vjpPlus(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a + b,
+            pullback: { v in
+                (v, v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] - b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: -)
+    public static func _vjpMin(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a - b,
+            pullback: { v in
+                (v, -v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] * b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (a * b, { v in
+            (v * b, v * a)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] / b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public func addingProduct(_ a: Self, _ b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].addingProduct(a[i], b[i]) }
+        return result
+    }
+
+    @derivative(of: addingProduct)
+    @_transparent
+    public func _vjpAddingProduct(
+        _ lhs: Self, _ rhs: Self
+    ) -> (value: Self, pullback: (Self) -> (Self, Self, Self)) {
+        (addingProduct(lhs, rhs), { v in (v, v * rhs, v * lhs) })
+    }
+
+    @_transparent
+    public func squareRoot() -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].squareRoot() }
+        return result
+    }
+
+    @_transparent
+    public func _vjpSquareRoot() -> (value: Self, pullback: (TangentVector) -> TangentVector) {
+        let y = self.squareRoot()
+        return (y, { v in v / (2 * y) })
+    }
+
+    /// The sum of the scalars in the vector.
+    @_alwaysEmitIntoClient
+    public func sum() -> Scalar {
+        // Implementation note: this eventually be defined to lower to either
+        // llvm.experimental.vector.reduce.fadd or an explicit tree-sum. Open-
+        // coding the tree sum is problematic, we probably need to define a
+        // Swift Builtin to support it.
+        //
+        // Use -0 so that LLVM can optimize away initial value + self[0].
+        var result = -Scalar.zero
+        for i in indices {
+            result += self[i]
+        }
+        return result
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @derivative(of: sum)
+    func _vjpSum() -> (
+        value: Scalar,
+        pullback: (Scalar.TangentVector) -> TangentVector
+    ) {
+        (sum(), { v in Self(repeating: Scalar(v)) })
+    }
+
+    @_transparent
+    public static prefix func - (a: Self) -> Self {
+        0 - a
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpNegate(a: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector)
+    ) {
+        (-a, { v in
+            -v
+        })
+    }
+
+    @_transparent
+    public static func + (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) + b
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a + b, { v in
+            (v.sum(), v)
+        })
+    }
+
+    @_transparent
+    public static func - (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) - b
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a - b, { v in
+            (v.sum(), -v)
+        })
+    }
+
+    @_transparent
+    public static func * (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) * b
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            ((v * rhs).sum(), v * lhs)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) / b
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            ((v / rhs).sum(), -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public static func + (a: Self, b: Scalar) -> Self {
+        a + Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs + rhs, { v in
+            (v, v.sum())
+        })
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Scalar) -> Self {
+        a - Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs - rhs, { v in
+            (v, -v.sum())
+        })
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Scalar) -> Self {
+        a * Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            (v * rhs, (v * lhs).sum())
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Scalar) -> Self {
+        a / Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, (-lhs / (rhs * rhs) * v).sum())
+        })
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Self) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Self) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Self) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Self) {
+        a = a / b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Scalar) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Scalar) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Scalar) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Scalar) {
+        a = a / b
+    }
+}

--- a/Sources/Differentiation/SIMDSTDLibOverloads/SIMD16+FloatSTDLibOverloads.swift
+++ b/Sources/Differentiation/SIMDSTDLibOverloads/SIMD16+FloatSTDLibOverloads.swift
@@ -1,0 +1,327 @@
+import _Differentiation
+
+extension SIMD16 where Scalar == Float {
+    @_transparent
+    public static func + (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] + b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: +)
+    public static func _vjpPlus(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a + b,
+            pullback: { v in
+                (v, v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] - b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: -)
+    public static func _vjpMin(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a - b,
+            pullback: { v in
+                (v, -v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] * b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (a * b, { v in
+            (v * b, v * a)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] / b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public func addingProduct(_ a: Self, _ b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].addingProduct(a[i], b[i]) }
+        return result
+    }
+
+    @derivative(of: addingProduct)
+    @_transparent
+    public func _vjpAddingProduct(
+        _ lhs: Self, _ rhs: Self
+    ) -> (value: Self, pullback: (Self) -> (Self, Self, Self)) {
+        (addingProduct(lhs, rhs), { v in (v, v * rhs, v * lhs) })
+    }
+
+    @_transparent
+    public func squareRoot() -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].squareRoot() }
+        return result
+    }
+
+    @_transparent
+    public func _vjpSquareRoot() -> (value: Self, pullback: (TangentVector) -> TangentVector) {
+        let y = self.squareRoot()
+        return (y, { v in v / (2 * y) })
+    }
+
+    /// The sum of the scalars in the vector.
+    @_alwaysEmitIntoClient
+    public func sum() -> Scalar {
+        // Implementation note: this eventually be defined to lower to either
+        // llvm.experimental.vector.reduce.fadd or an explicit tree-sum. Open-
+        // coding the tree sum is problematic, we probably need to define a
+        // Swift Builtin to support it.
+        //
+        // Use -0 so that LLVM can optimize away initial value + self[0].
+        var result = -Scalar.zero
+        for i in indices {
+            result += self[i]
+        }
+        return result
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @derivative(of: sum)
+    func _vjpSum() -> (
+        value: Scalar,
+        pullback: (Scalar.TangentVector) -> TangentVector
+    ) {
+        (sum(), { v in Self(repeating: Scalar(v)) })
+    }
+
+    @_transparent
+    public static prefix func - (a: Self) -> Self {
+        0 - a
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpNegate(a: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector)
+    ) {
+        (-a, { v in
+            -v
+        })
+    }
+
+    @_transparent
+    public static func + (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) + b
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a + b, { v in
+            (v.sum(), v)
+        })
+    }
+
+    @_transparent
+    public static func - (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) - b
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a - b, { v in
+            (v.sum(), -v)
+        })
+    }
+
+    @_transparent
+    public static func * (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) * b
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            ((v * rhs).sum(), v * lhs)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) / b
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            ((v / rhs).sum(), -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public static func + (a: Self, b: Scalar) -> Self {
+        a + Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs + rhs, { v in
+            (v, v.sum())
+        })
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Scalar) -> Self {
+        a - Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs - rhs, { v in
+            (v, -v.sum())
+        })
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Scalar) -> Self {
+        a * Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            (v * rhs, (v * lhs).sum())
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Scalar) -> Self {
+        a / Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, (-lhs / (rhs * rhs) * v).sum())
+        })
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Self) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Self) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Self) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Self) {
+        a = a / b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Scalar) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Scalar) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Scalar) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Scalar) {
+        a = a / b
+    }
+}

--- a/Sources/Differentiation/SIMDSTDLibOverloads/SIMD2+DoubleSTDLibOverloads.swift
+++ b/Sources/Differentiation/SIMDSTDLibOverloads/SIMD2+DoubleSTDLibOverloads.swift
@@ -1,0 +1,327 @@
+import _Differentiation
+
+extension SIMD2 where Scalar == Double {
+    @_transparent
+    public static func + (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] + b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: +)
+    public static func _vjpPlus(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a + b,
+            pullback: { v in
+                (v, v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] - b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: -)
+    public static func _vjpMin(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a - b,
+            pullback: { v in
+                (v, -v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] * b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (a * b, { v in
+            (v * b, v * a)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] / b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public func addingProduct(_ a: Self, _ b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].addingProduct(a[i], b[i]) }
+        return result
+    }
+
+    @derivative(of: addingProduct)
+    @_transparent
+    public func _vjpAddingProduct(
+        _ lhs: Self, _ rhs: Self
+    ) -> (value: Self, pullback: (Self) -> (Self, Self, Self)) {
+        (addingProduct(lhs, rhs), { v in (v, v * rhs, v * lhs) })
+    }
+
+    @_transparent
+    public func squareRoot() -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].squareRoot() }
+        return result
+    }
+
+    @_transparent
+    public func _vjpSquareRoot() -> (value: Self, pullback: (TangentVector) -> TangentVector) {
+        let y = self.squareRoot()
+        return (y, { v in v / (2 * y) })
+    }
+
+    /// The sum of the scalars in the vector.
+    @_alwaysEmitIntoClient
+    public func sum() -> Scalar {
+        // Implementation note: this eventually be defined to lower to either
+        // llvm.experimental.vector.reduce.fadd or an explicit tree-sum. Open-
+        // coding the tree sum is problematic, we probably need to define a
+        // Swift Builtin to support it.
+        //
+        // Use -0 so that LLVM can optimize away initial value + self[0].
+        var result = -Scalar.zero
+        for i in indices {
+            result += self[i]
+        }
+        return result
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @derivative(of: sum)
+    func _vjpSum() -> (
+        value: Scalar,
+        pullback: (Scalar.TangentVector) -> TangentVector
+    ) {
+        (sum(), { v in Self(repeating: Scalar(v)) })
+    }
+
+    @_transparent
+    public static prefix func - (a: Self) -> Self {
+        0 - a
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpNegate(a: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector)
+    ) {
+        (-a, { v in
+            -v
+        })
+    }
+
+    @_transparent
+    public static func + (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) + b
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a + b, { v in
+            (v.sum(), v)
+        })
+    }
+
+    @_transparent
+    public static func - (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) - b
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a - b, { v in
+            (v.sum(), -v)
+        })
+    }
+
+    @_transparent
+    public static func * (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) * b
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            ((v * rhs).sum(), v * lhs)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) / b
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            ((v / rhs).sum(), -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public static func + (a: Self, b: Scalar) -> Self {
+        a + Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs + rhs, { v in
+            (v, v.sum())
+        })
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Scalar) -> Self {
+        a - Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs - rhs, { v in
+            (v, -v.sum())
+        })
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Scalar) -> Self {
+        a * Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            (v * rhs, (v * lhs).sum())
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Scalar) -> Self {
+        a / Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, (-lhs / (rhs * rhs) * v).sum())
+        })
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Self) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Self) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Self) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Self) {
+        a = a / b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Scalar) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Scalar) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Scalar) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Scalar) {
+        a = a / b
+    }
+}

--- a/Sources/Differentiation/SIMDSTDLibOverloads/SIMD2+FloatSTDLibOverloads.swift
+++ b/Sources/Differentiation/SIMDSTDLibOverloads/SIMD2+FloatSTDLibOverloads.swift
@@ -1,0 +1,327 @@
+import _Differentiation
+
+extension SIMD2 where Scalar == Float {
+    @_transparent
+    public static func + (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] + b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: +)
+    public static func _vjpPlus(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a + b,
+            pullback: { v in
+                (v, v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] - b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: -)
+    public static func _vjpMin(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a - b,
+            pullback: { v in
+                (v, -v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] * b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (a * b, { v in
+            (v * b, v * a)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] / b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public func addingProduct(_ a: Self, _ b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].addingProduct(a[i], b[i]) }
+        return result
+    }
+
+    @derivative(of: addingProduct)
+    @_transparent
+    public func _vjpAddingProduct(
+        _ lhs: Self, _ rhs: Self
+    ) -> (value: Self, pullback: (Self) -> (Self, Self, Self)) {
+        (addingProduct(lhs, rhs), { v in (v, v * rhs, v * lhs) })
+    }
+
+    @_transparent
+    public func squareRoot() -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].squareRoot() }
+        return result
+    }
+
+    @_transparent
+    public func _vjpSquareRoot() -> (value: Self, pullback: (TangentVector) -> TangentVector) {
+        let y = self.squareRoot()
+        return (y, { v in v / (2 * y) })
+    }
+
+    /// The sum of the scalars in the vector.
+    @_alwaysEmitIntoClient
+    public func sum() -> Scalar {
+        // Implementation note: this eventually be defined to lower to either
+        // llvm.experimental.vector.reduce.fadd or an explicit tree-sum. Open-
+        // coding the tree sum is problematic, we probably need to define a
+        // Swift Builtin to support it.
+        //
+        // Use -0 so that LLVM can optimize away initial value + self[0].
+        var result = -Scalar.zero
+        for i in indices {
+            result += self[i]
+        }
+        return result
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @derivative(of: sum)
+    func _vjpSum() -> (
+        value: Scalar,
+        pullback: (Scalar.TangentVector) -> TangentVector
+    ) {
+        (sum(), { v in Self(repeating: Scalar(v)) })
+    }
+
+    @_transparent
+    public static prefix func - (a: Self) -> Self {
+        0 - a
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpNegate(a: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector)
+    ) {
+        (-a, { v in
+            -v
+        })
+    }
+
+    @_transparent
+    public static func + (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) + b
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a + b, { v in
+            (v.sum(), v)
+        })
+    }
+
+    @_transparent
+    public static func - (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) - b
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a - b, { v in
+            (v.sum(), -v)
+        })
+    }
+
+    @_transparent
+    public static func * (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) * b
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            ((v * rhs).sum(), v * lhs)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) / b
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            ((v / rhs).sum(), -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public static func + (a: Self, b: Scalar) -> Self {
+        a + Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs + rhs, { v in
+            (v, v.sum())
+        })
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Scalar) -> Self {
+        a - Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs - rhs, { v in
+            (v, -v.sum())
+        })
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Scalar) -> Self {
+        a * Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            (v * rhs, (v * lhs).sum())
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Scalar) -> Self {
+        a / Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, (-lhs / (rhs * rhs) * v).sum())
+        })
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Self) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Self) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Self) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Self) {
+        a = a / b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Scalar) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Scalar) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Scalar) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Scalar) {
+        a = a / b
+    }
+}

--- a/Sources/Differentiation/SIMDSTDLibOverloads/SIMD3+DoubleSTDLibOverloads.swift
+++ b/Sources/Differentiation/SIMDSTDLibOverloads/SIMD3+DoubleSTDLibOverloads.swift
@@ -1,0 +1,327 @@
+import _Differentiation
+
+extension SIMD3 where Scalar == Double {
+    @_transparent
+    public static func + (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] + b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: +)
+    public static func _vjpPlus(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a + b,
+            pullback: { v in
+                (v, v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] - b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: -)
+    public static func _vjpMin(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a - b,
+            pullback: { v in
+                (v, -v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] * b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (a * b, { v in
+            (v * b, v * a)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] / b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public func addingProduct(_ a: Self, _ b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].addingProduct(a[i], b[i]) }
+        return result
+    }
+
+    @derivative(of: addingProduct)
+    @_transparent
+    public func _vjpAddingProduct(
+        _ lhs: Self, _ rhs: Self
+    ) -> (value: Self, pullback: (Self) -> (Self, Self, Self)) {
+        (addingProduct(lhs, rhs), { v in (v, v * rhs, v * lhs) })
+    }
+
+    @_transparent
+    public func squareRoot() -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].squareRoot() }
+        return result
+    }
+
+    @_transparent
+    public func _vjpSquareRoot() -> (value: Self, pullback: (TangentVector) -> TangentVector) {
+        let y = self.squareRoot()
+        return (y, { v in v / (2 * y) })
+    }
+
+    /// The sum of the scalars in the vector.
+    @_alwaysEmitIntoClient
+    public func sum() -> Scalar {
+        // Implementation note: this eventually be defined to lower to either
+        // llvm.experimental.vector.reduce.fadd or an explicit tree-sum. Open-
+        // coding the tree sum is problematic, we probably need to define a
+        // Swift Builtin to support it.
+        //
+        // Use -0 so that LLVM can optimize away initial value + self[0].
+        var result = -Scalar.zero
+        for i in indices {
+            result += self[i]
+        }
+        return result
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @derivative(of: sum)
+    func _vjpSum() -> (
+        value: Scalar,
+        pullback: (Scalar.TangentVector) -> TangentVector
+    ) {
+        (sum(), { v in Self(repeating: Scalar(v)) })
+    }
+
+    @_transparent
+    public static prefix func - (a: Self) -> Self {
+        0 - a
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpNegate(a: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector)
+    ) {
+        (-a, { v in
+            -v
+        })
+    }
+
+    @_transparent
+    public static func + (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) + b
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a + b, { v in
+            (v.sum(), v)
+        })
+    }
+
+    @_transparent
+    public static func - (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) - b
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a - b, { v in
+            (v.sum(), -v)
+        })
+    }
+
+    @_transparent
+    public static func * (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) * b
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            ((v * rhs).sum(), v * lhs)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) / b
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            ((v / rhs).sum(), -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public static func + (a: Self, b: Scalar) -> Self {
+        a + Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs + rhs, { v in
+            (v, v.sum())
+        })
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Scalar) -> Self {
+        a - Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs - rhs, { v in
+            (v, -v.sum())
+        })
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Scalar) -> Self {
+        a * Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            (v * rhs, (v * lhs).sum())
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Scalar) -> Self {
+        a / Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, (-lhs / (rhs * rhs) * v).sum())
+        })
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Self) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Self) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Self) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Self) {
+        a = a / b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Scalar) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Scalar) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Scalar) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Scalar) {
+        a = a / b
+    }
+}

--- a/Sources/Differentiation/SIMDSTDLibOverloads/SIMD3+FloatSTDLibOverloads.swift
+++ b/Sources/Differentiation/SIMDSTDLibOverloads/SIMD3+FloatSTDLibOverloads.swift
@@ -1,0 +1,327 @@
+import _Differentiation
+
+extension SIMD3 where Scalar == Float {
+    @_transparent
+    public static func + (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] + b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: +)
+    public static func _vjpPlus(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a + b,
+            pullback: { v in
+                (v, v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] - b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: -)
+    public static func _vjpMin(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a - b,
+            pullback: { v in
+                (v, -v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] * b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (a * b, { v in
+            (v * b, v * a)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] / b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public func addingProduct(_ a: Self, _ b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].addingProduct(a[i], b[i]) }
+        return result
+    }
+
+    @derivative(of: addingProduct)
+    @_transparent
+    public func _vjpAddingProduct(
+        _ lhs: Self, _ rhs: Self
+    ) -> (value: Self, pullback: (Self) -> (Self, Self, Self)) {
+        (addingProduct(lhs, rhs), { v in (v, v * rhs, v * lhs) })
+    }
+
+    @_transparent
+    public func squareRoot() -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].squareRoot() }
+        return result
+    }
+
+    @_transparent
+    public func _vjpSquareRoot() -> (value: Self, pullback: (TangentVector) -> TangentVector) {
+        let y = self.squareRoot()
+        return (y, { v in v / (2 * y) })
+    }
+
+    /// The sum of the scalars in the vector.
+    @_alwaysEmitIntoClient
+    public func sum() -> Scalar {
+        // Implementation note: this eventually be defined to lower to either
+        // llvm.experimental.vector.reduce.fadd or an explicit tree-sum. Open-
+        // coding the tree sum is problematic, we probably need to define a
+        // Swift Builtin to support it.
+        //
+        // Use -0 so that LLVM can optimize away initial value + self[0].
+        var result = -Scalar.zero
+        for i in indices {
+            result += self[i]
+        }
+        return result
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @derivative(of: sum)
+    func _vjpSum() -> (
+        value: Scalar,
+        pullback: (Scalar.TangentVector) -> TangentVector
+    ) {
+        (sum(), { v in Self(repeating: Scalar(v)) })
+    }
+
+    @_transparent
+    public static prefix func - (a: Self) -> Self {
+        0 - a
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpNegate(a: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector)
+    ) {
+        (-a, { v in
+            -v
+        })
+    }
+
+    @_transparent
+    public static func + (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) + b
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a + b, { v in
+            (v.sum(), v)
+        })
+    }
+
+    @_transparent
+    public static func - (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) - b
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a - b, { v in
+            (v.sum(), -v)
+        })
+    }
+
+    @_transparent
+    public static func * (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) * b
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            ((v * rhs).sum(), v * lhs)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) / b
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            ((v / rhs).sum(), -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public static func + (a: Self, b: Scalar) -> Self {
+        a + Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs + rhs, { v in
+            (v, v.sum())
+        })
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Scalar) -> Self {
+        a - Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs - rhs, { v in
+            (v, -v.sum())
+        })
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Scalar) -> Self {
+        a * Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            (v * rhs, (v * lhs).sum())
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Scalar) -> Self {
+        a / Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, (-lhs / (rhs * rhs) * v).sum())
+        })
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Self) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Self) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Self) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Self) {
+        a = a / b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Scalar) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Scalar) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Scalar) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Scalar) {
+        a = a / b
+    }
+}

--- a/Sources/Differentiation/SIMDSTDLibOverloads/SIMD32+DoubleSTDLibOverloads.swift
+++ b/Sources/Differentiation/SIMDSTDLibOverloads/SIMD32+DoubleSTDLibOverloads.swift
@@ -1,0 +1,327 @@
+import _Differentiation
+
+extension SIMD32 where Scalar == Double {
+    @_transparent
+    public static func + (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] + b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: +)
+    public static func _vjpPlus(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a + b,
+            pullback: { v in
+                (v, v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] - b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: -)
+    public static func _vjpMin(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a - b,
+            pullback: { v in
+                (v, -v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] * b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (a * b, { v in
+            (v * b, v * a)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] / b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public func addingProduct(_ a: Self, _ b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].addingProduct(a[i], b[i]) }
+        return result
+    }
+
+    @derivative(of: addingProduct)
+    @_transparent
+    public func _vjpAddingProduct(
+        _ lhs: Self, _ rhs: Self
+    ) -> (value: Self, pullback: (Self) -> (Self, Self, Self)) {
+        (addingProduct(lhs, rhs), { v in (v, v * rhs, v * lhs) })
+    }
+
+    @_transparent
+    public func squareRoot() -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].squareRoot() }
+        return result
+    }
+
+    @_transparent
+    public func _vjpSquareRoot() -> (value: Self, pullback: (TangentVector) -> TangentVector) {
+        let y = self.squareRoot()
+        return (y, { v in v / (2 * y) })
+    }
+
+    /// The sum of the scalars in the vector.
+    @_alwaysEmitIntoClient
+    public func sum() -> Scalar {
+        // Implementation note: this eventually be defined to lower to either
+        // llvm.experimental.vector.reduce.fadd or an explicit tree-sum. Open-
+        // coding the tree sum is problematic, we probably need to define a
+        // Swift Builtin to support it.
+        //
+        // Use -0 so that LLVM can optimize away initial value + self[0].
+        var result = -Scalar.zero
+        for i in indices {
+            result += self[i]
+        }
+        return result
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @derivative(of: sum)
+    func _vjpSum() -> (
+        value: Scalar,
+        pullback: (Scalar.TangentVector) -> TangentVector
+    ) {
+        (sum(), { v in Self(repeating: Scalar(v)) })
+    }
+
+    @_transparent
+    public static prefix func - (a: Self) -> Self {
+        0 - a
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpNegate(a: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector)
+    ) {
+        (-a, { v in
+            -v
+        })
+    }
+
+    @_transparent
+    public static func + (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) + b
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a + b, { v in
+            (v.sum(), v)
+        })
+    }
+
+    @_transparent
+    public static func - (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) - b
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a - b, { v in
+            (v.sum(), -v)
+        })
+    }
+
+    @_transparent
+    public static func * (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) * b
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            ((v * rhs).sum(), v * lhs)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) / b
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            ((v / rhs).sum(), -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public static func + (a: Self, b: Scalar) -> Self {
+        a + Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs + rhs, { v in
+            (v, v.sum())
+        })
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Scalar) -> Self {
+        a - Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs - rhs, { v in
+            (v, -v.sum())
+        })
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Scalar) -> Self {
+        a * Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            (v * rhs, (v * lhs).sum())
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Scalar) -> Self {
+        a / Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, (-lhs / (rhs * rhs) * v).sum())
+        })
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Self) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Self) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Self) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Self) {
+        a = a / b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Scalar) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Scalar) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Scalar) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Scalar) {
+        a = a / b
+    }
+}

--- a/Sources/Differentiation/SIMDSTDLibOverloads/SIMD32+FloatSTDLibOverloads.swift
+++ b/Sources/Differentiation/SIMDSTDLibOverloads/SIMD32+FloatSTDLibOverloads.swift
@@ -1,0 +1,327 @@
+import _Differentiation
+
+extension SIMD32 where Scalar == Float {
+    @_transparent
+    public static func + (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] + b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: +)
+    public static func _vjpPlus(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a + b,
+            pullback: { v in
+                (v, v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] - b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: -)
+    public static func _vjpMin(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a - b,
+            pullback: { v in
+                (v, -v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] * b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (a * b, { v in
+            (v * b, v * a)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] / b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public func addingProduct(_ a: Self, _ b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].addingProduct(a[i], b[i]) }
+        return result
+    }
+
+    @derivative(of: addingProduct)
+    @_transparent
+    public func _vjpAddingProduct(
+        _ lhs: Self, _ rhs: Self
+    ) -> (value: Self, pullback: (Self) -> (Self, Self, Self)) {
+        (addingProduct(lhs, rhs), { v in (v, v * rhs, v * lhs) })
+    }
+
+    @_transparent
+    public func squareRoot() -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].squareRoot() }
+        return result
+    }
+
+    @_transparent
+    public func _vjpSquareRoot() -> (value: Self, pullback: (TangentVector) -> TangentVector) {
+        let y = self.squareRoot()
+        return (y, { v in v / (2 * y) })
+    }
+
+    /// The sum of the scalars in the vector.
+    @_alwaysEmitIntoClient
+    public func sum() -> Scalar {
+        // Implementation note: this eventually be defined to lower to either
+        // llvm.experimental.vector.reduce.fadd or an explicit tree-sum. Open-
+        // coding the tree sum is problematic, we probably need to define a
+        // Swift Builtin to support it.
+        //
+        // Use -0 so that LLVM can optimize away initial value + self[0].
+        var result = -Scalar.zero
+        for i in indices {
+            result += self[i]
+        }
+        return result
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @derivative(of: sum)
+    func _vjpSum() -> (
+        value: Scalar,
+        pullback: (Scalar.TangentVector) -> TangentVector
+    ) {
+        (sum(), { v in Self(repeating: Scalar(v)) })
+    }
+
+    @_transparent
+    public static prefix func - (a: Self) -> Self {
+        0 - a
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpNegate(a: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector)
+    ) {
+        (-a, { v in
+            -v
+        })
+    }
+
+    @_transparent
+    public static func + (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) + b
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a + b, { v in
+            (v.sum(), v)
+        })
+    }
+
+    @_transparent
+    public static func - (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) - b
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a - b, { v in
+            (v.sum(), -v)
+        })
+    }
+
+    @_transparent
+    public static func * (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) * b
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            ((v * rhs).sum(), v * lhs)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) / b
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            ((v / rhs).sum(), -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public static func + (a: Self, b: Scalar) -> Self {
+        a + Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs + rhs, { v in
+            (v, v.sum())
+        })
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Scalar) -> Self {
+        a - Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs - rhs, { v in
+            (v, -v.sum())
+        })
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Scalar) -> Self {
+        a * Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            (v * rhs, (v * lhs).sum())
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Scalar) -> Self {
+        a / Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, (-lhs / (rhs * rhs) * v).sum())
+        })
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Self) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Self) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Self) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Self) {
+        a = a / b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Scalar) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Scalar) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Scalar) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Scalar) {
+        a = a / b
+    }
+}

--- a/Sources/Differentiation/SIMDSTDLibOverloads/SIMD4+DoubleSTDLibOverloads.swift
+++ b/Sources/Differentiation/SIMDSTDLibOverloads/SIMD4+DoubleSTDLibOverloads.swift
@@ -1,0 +1,327 @@
+import _Differentiation
+
+extension SIMD4 where Scalar == Double {
+    @_transparent
+    public static func + (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] + b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: +)
+    public static func _vjpPlus(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a + b,
+            pullback: { v in
+                (v, v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] - b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: -)
+    public static func _vjpMin(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a - b,
+            pullback: { v in
+                (v, -v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] * b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (a * b, { v in
+            (v * b, v * a)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] / b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public func addingProduct(_ a: Self, _ b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].addingProduct(a[i], b[i]) }
+        return result
+    }
+
+    @derivative(of: addingProduct)
+    @_transparent
+    public func _vjpAddingProduct(
+        _ lhs: Self, _ rhs: Self
+    ) -> (value: Self, pullback: (Self) -> (Self, Self, Self)) {
+        (addingProduct(lhs, rhs), { v in (v, v * rhs, v * lhs) })
+    }
+
+    @_transparent
+    public func squareRoot() -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].squareRoot() }
+        return result
+    }
+
+    @_transparent
+    public func _vjpSquareRoot() -> (value: Self, pullback: (TangentVector) -> TangentVector) {
+        let y = self.squareRoot()
+        return (y, { v in v / (2 * y) })
+    }
+
+    /// The sum of the scalars in the vector.
+    @_alwaysEmitIntoClient
+    public func sum() -> Scalar {
+        // Implementation note: this eventually be defined to lower to either
+        // llvm.experimental.vector.reduce.fadd or an explicit tree-sum. Open-
+        // coding the tree sum is problematic, we probably need to define a
+        // Swift Builtin to support it.
+        //
+        // Use -0 so that LLVM can optimize away initial value + self[0].
+        var result = -Scalar.zero
+        for i in indices {
+            result += self[i]
+        }
+        return result
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @derivative(of: sum)
+    func _vjpSum() -> (
+        value: Scalar,
+        pullback: (Scalar.TangentVector) -> TangentVector
+    ) {
+        (sum(), { v in Self(repeating: Scalar(v)) })
+    }
+
+    @_transparent
+    public static prefix func - (a: Self) -> Self {
+        0 - a
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpNegate(a: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector)
+    ) {
+        (-a, { v in
+            -v
+        })
+    }
+
+    @_transparent
+    public static func + (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) + b
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a + b, { v in
+            (v.sum(), v)
+        })
+    }
+
+    @_transparent
+    public static func - (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) - b
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a - b, { v in
+            (v.sum(), -v)
+        })
+    }
+
+    @_transparent
+    public static func * (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) * b
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            ((v * rhs).sum(), v * lhs)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) / b
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            ((v / rhs).sum(), -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public static func + (a: Self, b: Scalar) -> Self {
+        a + Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs + rhs, { v in
+            (v, v.sum())
+        })
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Scalar) -> Self {
+        a - Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs - rhs, { v in
+            (v, -v.sum())
+        })
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Scalar) -> Self {
+        a * Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            (v * rhs, (v * lhs).sum())
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Scalar) -> Self {
+        a / Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, (-lhs / (rhs * rhs) * v).sum())
+        })
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Self) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Self) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Self) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Self) {
+        a = a / b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Scalar) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Scalar) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Scalar) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Scalar) {
+        a = a / b
+    }
+}

--- a/Sources/Differentiation/SIMDSTDLibOverloads/SIMD4+FloatSTDLibOverloads.swift
+++ b/Sources/Differentiation/SIMDSTDLibOverloads/SIMD4+FloatSTDLibOverloads.swift
@@ -1,0 +1,327 @@
+import _Differentiation
+
+extension SIMD4 where Scalar == Float {
+    @_transparent
+    public static func + (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] + b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: +)
+    public static func _vjpPlus(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a + b,
+            pullback: { v in
+                (v, v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] - b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: -)
+    public static func _vjpMin(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a - b,
+            pullback: { v in
+                (v, -v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] * b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (a * b, { v in
+            (v * b, v * a)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] / b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public func addingProduct(_ a: Self, _ b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].addingProduct(a[i], b[i]) }
+        return result
+    }
+
+    @derivative(of: addingProduct)
+    @_transparent
+    public func _vjpAddingProduct(
+        _ lhs: Self, _ rhs: Self
+    ) -> (value: Self, pullback: (Self) -> (Self, Self, Self)) {
+        (addingProduct(lhs, rhs), { v in (v, v * rhs, v * lhs) })
+    }
+
+    @_transparent
+    public func squareRoot() -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].squareRoot() }
+        return result
+    }
+
+    @_transparent
+    public func _vjpSquareRoot() -> (value: Self, pullback: (TangentVector) -> TangentVector) {
+        let y = self.squareRoot()
+        return (y, { v in v / (2 * y) })
+    }
+
+    /// The sum of the scalars in the vector.
+    @_alwaysEmitIntoClient
+    public func sum() -> Scalar {
+        // Implementation note: this eventually be defined to lower to either
+        // llvm.experimental.vector.reduce.fadd or an explicit tree-sum. Open-
+        // coding the tree sum is problematic, we probably need to define a
+        // Swift Builtin to support it.
+        //
+        // Use -0 so that LLVM can optimize away initial value + self[0].
+        var result = -Scalar.zero
+        for i in indices {
+            result += self[i]
+        }
+        return result
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @derivative(of: sum)
+    func _vjpSum() -> (
+        value: Scalar,
+        pullback: (Scalar.TangentVector) -> TangentVector
+    ) {
+        (sum(), { v in Self(repeating: Scalar(v)) })
+    }
+
+    @_transparent
+    public static prefix func - (a: Self) -> Self {
+        0 - a
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpNegate(a: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector)
+    ) {
+        (-a, { v in
+            -v
+        })
+    }
+
+    @_transparent
+    public static func + (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) + b
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a + b, { v in
+            (v.sum(), v)
+        })
+    }
+
+    @_transparent
+    public static func - (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) - b
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a - b, { v in
+            (v.sum(), -v)
+        })
+    }
+
+    @_transparent
+    public static func * (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) * b
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            ((v * rhs).sum(), v * lhs)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) / b
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            ((v / rhs).sum(), -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public static func + (a: Self, b: Scalar) -> Self {
+        a + Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs + rhs, { v in
+            (v, v.sum())
+        })
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Scalar) -> Self {
+        a - Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs - rhs, { v in
+            (v, -v.sum())
+        })
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Scalar) -> Self {
+        a * Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            (v * rhs, (v * lhs).sum())
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Scalar) -> Self {
+        a / Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, (-lhs / (rhs * rhs) * v).sum())
+        })
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Self) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Self) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Self) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Self) {
+        a = a / b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Scalar) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Scalar) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Scalar) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Scalar) {
+        a = a / b
+    }
+}

--- a/Sources/Differentiation/SIMDSTDLibOverloads/SIMD64+DoubleSTDLibOverloads.swift
+++ b/Sources/Differentiation/SIMDSTDLibOverloads/SIMD64+DoubleSTDLibOverloads.swift
@@ -1,0 +1,327 @@
+import _Differentiation
+
+extension SIMD64 where Scalar == Double {
+    @_transparent
+    public static func + (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] + b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: +)
+    public static func _vjpPlus(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a + b,
+            pullback: { v in
+                (v, v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] - b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: -)
+    public static func _vjpMin(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a - b,
+            pullback: { v in
+                (v, -v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] * b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (a * b, { v in
+            (v * b, v * a)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] / b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public func addingProduct(_ a: Self, _ b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].addingProduct(a[i], b[i]) }
+        return result
+    }
+
+    @derivative(of: addingProduct)
+    @_transparent
+    public func _vjpAddingProduct(
+        _ lhs: Self, _ rhs: Self
+    ) -> (value: Self, pullback: (Self) -> (Self, Self, Self)) {
+        (addingProduct(lhs, rhs), { v in (v, v * rhs, v * lhs) })
+    }
+
+    @_transparent
+    public func squareRoot() -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].squareRoot() }
+        return result
+    }
+
+    @_transparent
+    public func _vjpSquareRoot() -> (value: Self, pullback: (TangentVector) -> TangentVector) {
+        let y = self.squareRoot()
+        return (y, { v in v / (2 * y) })
+    }
+
+    /// The sum of the scalars in the vector.
+    @_alwaysEmitIntoClient
+    public func sum() -> Scalar {
+        // Implementation note: this eventually be defined to lower to either
+        // llvm.experimental.vector.reduce.fadd or an explicit tree-sum. Open-
+        // coding the tree sum is problematic, we probably need to define a
+        // Swift Builtin to support it.
+        //
+        // Use -0 so that LLVM can optimize away initial value + self[0].
+        var result = -Scalar.zero
+        for i in indices {
+            result += self[i]
+        }
+        return result
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @derivative(of: sum)
+    func _vjpSum() -> (
+        value: Scalar,
+        pullback: (Scalar.TangentVector) -> TangentVector
+    ) {
+        (sum(), { v in Self(repeating: Scalar(v)) })
+    }
+
+    @_transparent
+    public static prefix func - (a: Self) -> Self {
+        0 - a
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpNegate(a: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector)
+    ) {
+        (-a, { v in
+            -v
+        })
+    }
+
+    @_transparent
+    public static func + (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) + b
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a + b, { v in
+            (v.sum(), v)
+        })
+    }
+
+    @_transparent
+    public static func - (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) - b
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a - b, { v in
+            (v.sum(), -v)
+        })
+    }
+
+    @_transparent
+    public static func * (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) * b
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            ((v * rhs).sum(), v * lhs)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) / b
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            ((v / rhs).sum(), -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public static func + (a: Self, b: Scalar) -> Self {
+        a + Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs + rhs, { v in
+            (v, v.sum())
+        })
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Scalar) -> Self {
+        a - Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs - rhs, { v in
+            (v, -v.sum())
+        })
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Scalar) -> Self {
+        a * Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            (v * rhs, (v * lhs).sum())
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Scalar) -> Self {
+        a / Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, (-lhs / (rhs * rhs) * v).sum())
+        })
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Self) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Self) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Self) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Self) {
+        a = a / b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Scalar) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Scalar) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Scalar) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Scalar) {
+        a = a / b
+    }
+}

--- a/Sources/Differentiation/SIMDSTDLibOverloads/SIMD64+FloatSTDLibOverloads.swift
+++ b/Sources/Differentiation/SIMDSTDLibOverloads/SIMD64+FloatSTDLibOverloads.swift
@@ -1,0 +1,327 @@
+import _Differentiation
+
+extension SIMD64 where Scalar == Float {
+    @_transparent
+    public static func + (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] + b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: +)
+    public static func _vjpPlus(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a + b,
+            pullback: { v in
+                (v, v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] - b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: -)
+    public static func _vjpMin(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a - b,
+            pullback: { v in
+                (v, -v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] * b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (a * b, { v in
+            (v * b, v * a)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] / b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public func addingProduct(_ a: Self, _ b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].addingProduct(a[i], b[i]) }
+        return result
+    }
+
+    @derivative(of: addingProduct)
+    @_transparent
+    public func _vjpAddingProduct(
+        _ lhs: Self, _ rhs: Self
+    ) -> (value: Self, pullback: (Self) -> (Self, Self, Self)) {
+        (addingProduct(lhs, rhs), { v in (v, v * rhs, v * lhs) })
+    }
+
+    @_transparent
+    public func squareRoot() -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].squareRoot() }
+        return result
+    }
+
+    @_transparent
+    public func _vjpSquareRoot() -> (value: Self, pullback: (TangentVector) -> TangentVector) {
+        let y = self.squareRoot()
+        return (y, { v in v / (2 * y) })
+    }
+
+    /// The sum of the scalars in the vector.
+    @_alwaysEmitIntoClient
+    public func sum() -> Scalar {
+        // Implementation note: this eventually be defined to lower to either
+        // llvm.experimental.vector.reduce.fadd or an explicit tree-sum. Open-
+        // coding the tree sum is problematic, we probably need to define a
+        // Swift Builtin to support it.
+        //
+        // Use -0 so that LLVM can optimize away initial value + self[0].
+        var result = -Scalar.zero
+        for i in indices {
+            result += self[i]
+        }
+        return result
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @derivative(of: sum)
+    func _vjpSum() -> (
+        value: Scalar,
+        pullback: (Scalar.TangentVector) -> TangentVector
+    ) {
+        (sum(), { v in Self(repeating: Scalar(v)) })
+    }
+
+    @_transparent
+    public static prefix func - (a: Self) -> Self {
+        0 - a
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpNegate(a: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector)
+    ) {
+        (-a, { v in
+            -v
+        })
+    }
+
+    @_transparent
+    public static func + (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) + b
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a + b, { v in
+            (v.sum(), v)
+        })
+    }
+
+    @_transparent
+    public static func - (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) - b
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a - b, { v in
+            (v.sum(), -v)
+        })
+    }
+
+    @_transparent
+    public static func * (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) * b
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            ((v * rhs).sum(), v * lhs)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) / b
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            ((v / rhs).sum(), -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public static func + (a: Self, b: Scalar) -> Self {
+        a + Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs + rhs, { v in
+            (v, v.sum())
+        })
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Scalar) -> Self {
+        a - Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs - rhs, { v in
+            (v, -v.sum())
+        })
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Scalar) -> Self {
+        a * Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            (v * rhs, (v * lhs).sum())
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Scalar) -> Self {
+        a / Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, (-lhs / (rhs * rhs) * v).sum())
+        })
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Self) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Self) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Self) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Self) {
+        a = a / b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Scalar) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Scalar) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Scalar) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Scalar) {
+        a = a / b
+    }
+}

--- a/Sources/Differentiation/SIMDSTDLibOverloads/SIMD8+DoubleSTDLibOverloads.swift
+++ b/Sources/Differentiation/SIMDSTDLibOverloads/SIMD8+DoubleSTDLibOverloads.swift
@@ -1,0 +1,327 @@
+import _Differentiation
+
+extension SIMD8 where Scalar == Double {
+    @_transparent
+    public static func + (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] + b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: +)
+    public static func _vjpPlus(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a + b,
+            pullback: { v in
+                (v, v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] - b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: -)
+    public static func _vjpMin(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a - b,
+            pullback: { v in
+                (v, -v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] * b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (a * b, { v in
+            (v * b, v * a)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] / b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public func addingProduct(_ a: Self, _ b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].addingProduct(a[i], b[i]) }
+        return result
+    }
+
+    @derivative(of: addingProduct)
+    @_transparent
+    public func _vjpAddingProduct(
+        _ lhs: Self, _ rhs: Self
+    ) -> (value: Self, pullback: (Self) -> (Self, Self, Self)) {
+        (addingProduct(lhs, rhs), { v in (v, v * rhs, v * lhs) })
+    }
+
+    @_transparent
+    public func squareRoot() -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].squareRoot() }
+        return result
+    }
+
+    @_transparent
+    public func _vjpSquareRoot() -> (value: Self, pullback: (TangentVector) -> TangentVector) {
+        let y = self.squareRoot()
+        return (y, { v in v / (2 * y) })
+    }
+
+    /// The sum of the scalars in the vector.
+    @_alwaysEmitIntoClient
+    public func sum() -> Scalar {
+        // Implementation note: this eventually be defined to lower to either
+        // llvm.experimental.vector.reduce.fadd or an explicit tree-sum. Open-
+        // coding the tree sum is problematic, we probably need to define a
+        // Swift Builtin to support it.
+        //
+        // Use -0 so that LLVM can optimize away initial value + self[0].
+        var result = -Scalar.zero
+        for i in indices {
+            result += self[i]
+        }
+        return result
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @derivative(of: sum)
+    func _vjpSum() -> (
+        value: Scalar,
+        pullback: (Scalar.TangentVector) -> TangentVector
+    ) {
+        (sum(), { v in Self(repeating: Scalar(v)) })
+    }
+
+    @_transparent
+    public static prefix func - (a: Self) -> Self {
+        0 - a
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpNegate(a: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector)
+    ) {
+        (-a, { v in
+            -v
+        })
+    }
+
+    @_transparent
+    public static func + (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) + b
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a + b, { v in
+            (v.sum(), v)
+        })
+    }
+
+    @_transparent
+    public static func - (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) - b
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a - b, { v in
+            (v.sum(), -v)
+        })
+    }
+
+    @_transparent
+    public static func * (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) * b
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            ((v * rhs).sum(), v * lhs)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) / b
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            ((v / rhs).sum(), -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public static func + (a: Self, b: Scalar) -> Self {
+        a + Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs + rhs, { v in
+            (v, v.sum())
+        })
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Scalar) -> Self {
+        a - Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs - rhs, { v in
+            (v, -v.sum())
+        })
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Scalar) -> Self {
+        a * Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            (v * rhs, (v * lhs).sum())
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Scalar) -> Self {
+        a / Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, (-lhs / (rhs * rhs) * v).sum())
+        })
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Self) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Self) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Self) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Self) {
+        a = a / b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Scalar) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Scalar) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Scalar) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Scalar) {
+        a = a / b
+    }
+}

--- a/Sources/Differentiation/SIMDSTDLibOverloads/SIMD8+FloatSTDLibOverloads.swift
+++ b/Sources/Differentiation/SIMDSTDLibOverloads/SIMD8+FloatSTDLibOverloads.swift
@@ -1,0 +1,327 @@
+import _Differentiation
+
+extension SIMD8 where Scalar == Float {
+    @_transparent
+    public static func + (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] + b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: +)
+    public static func _vjpPlus(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a + b,
+            pullback: { v in
+                (v, v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] - b[i] }
+        return result
+    }
+
+    @_transparent
+    @derivative(of: -)
+    public static func _vjpMin(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (Self.TangentVector) -> (Self.TangentVector, Self.TangentVector)
+    ) {
+        (
+            value: a - b,
+            pullback: { v in
+                (v, -v)
+            }
+        )
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] * b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(a: Self, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (a * b, { v in
+            (v * b, v * a)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = a[i] / b[i] }
+        return result
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public func addingProduct(_ a: Self, _ b: Self) -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].addingProduct(a[i], b[i]) }
+        return result
+    }
+
+    @derivative(of: addingProduct)
+    @_transparent
+    public func _vjpAddingProduct(
+        _ lhs: Self, _ rhs: Self
+    ) -> (value: Self, pullback: (Self) -> (Self, Self, Self)) {
+        (addingProduct(lhs, rhs), { v in (v, v * rhs, v * lhs) })
+    }
+
+    @_transparent
+    public func squareRoot() -> Self {
+        var result = Self()
+        for i in result.indices { result[i] = self[i].squareRoot() }
+        return result
+    }
+
+    @_transparent
+    public func _vjpSquareRoot() -> (value: Self, pullback: (TangentVector) -> TangentVector) {
+        let y = self.squareRoot()
+        return (y, { v in v / (2 * y) })
+    }
+
+    /// The sum of the scalars in the vector.
+    @_alwaysEmitIntoClient
+    public func sum() -> Scalar {
+        // Implementation note: this eventually be defined to lower to either
+        // llvm.experimental.vector.reduce.fadd or an explicit tree-sum. Open-
+        // coding the tree sum is problematic, we probably need to define a
+        // Swift Builtin to support it.
+        //
+        // Use -0 so that LLVM can optimize away initial value + self[0].
+        var result = -Scalar.zero
+        for i in indices {
+            result += self[i]
+        }
+        return result
+    }
+
+    @inlinable
+    @_alwaysEmitIntoClient
+    @derivative(of: sum)
+    func _vjpSum() -> (
+        value: Scalar,
+        pullback: (Scalar.TangentVector) -> TangentVector
+    ) {
+        (sum(), { v in Self(repeating: Scalar(v)) })
+    }
+
+    @_transparent
+    public static prefix func - (a: Self) -> Self {
+        0 - a
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpNegate(a: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector)
+    ) {
+        (-a, { v in
+            -v
+        })
+    }
+
+    @_transparent
+    public static func + (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) + b
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a + b, { v in
+            (v.sum(), v)
+        })
+    }
+
+    @_transparent
+    public static func - (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) - b
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(a: Scalar, b: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (a - b, { v in
+            (v.sum(), -v)
+        })
+    }
+
+    @_transparent
+    public static func * (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) * b
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            ((v * rhs).sum(), v * lhs)
+        })
+    }
+
+    @_transparent
+    public static func / (a: Scalar, b: Self) -> Self {
+        Self(repeating: a) / b
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Scalar, rhs: Self) -> (
+        value: Self,
+        pullback: (TangentVector) -> (Scalar.TangentVector, TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            ((v / rhs).sum(), -lhs / (rhs * rhs) * v)
+        })
+    }
+
+    @_transparent
+    public static func + (a: Self, b: Scalar) -> Self {
+        a + Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: +)
+    static func _vjpAdd(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs + rhs, { v in
+            (v, v.sum())
+        })
+    }
+
+    @_transparent
+    public static func - (a: Self, b: Scalar) -> Self {
+        a - Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: -)
+    static func _vjpSubtract(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs - rhs, { v in
+            (v, -v.sum())
+        })
+    }
+
+    @_transparent
+    public static func * (a: Self, b: Scalar) -> Self {
+        a * Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: *)
+    static func _vjpMultiply(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs * rhs, { v in
+            (v * rhs, (v * lhs).sum())
+        })
+    }
+
+    @_transparent
+    public static func / (a: Self, b: Scalar) -> Self {
+        a / Self(repeating: b)
+    }
+
+    @inlinable
+    @derivative(of: /)
+    static func _vjpDivide(lhs: Self, rhs: Scalar) -> (
+        value: Self,
+        pullback: (TangentVector) -> (TangentVector, Scalar.TangentVector)
+    ) {
+        (lhs / rhs, { v in
+            (v / rhs, (-lhs / (rhs * rhs) * v).sum())
+        })
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Self) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Self) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Self) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Self) {
+        a = a / b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func += (a: inout Self, b: Scalar) {
+        a = a + b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func -= (a: inout Self, b: Scalar) {
+        a = a - b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func *= (a: inout Self, b: Scalar) {
+        a = a * b
+    }
+
+    @differentiable(reverse)
+    @_transparent
+    public static func /= (a: inout Self, b: Scalar) {
+        a = a / b
+    }
+}


### PR DESCRIPTION
Lived in swift-numerics-differentiable for historical reasons. Now moved here. 