### PR TITLE
feat: enable inlinearray.init vjp now that compiler is fixed

### DIFF
--- a/Sources/Differentiation/InlineArray+Differentiation.swift
+++ b/Sources/Differentiation/InlineArray+Differentiation.swift
@@ -13,23 +13,23 @@ extension InlineArray: @retroactive Differentiable where Element: Differentiable
         }
     }
 
-    // not available yet due to a compiler issue. This is in main as of 2025/05/25. Part of Swift 6.3
-    /*
-     @derivative(of: init)
-     @_alwaysEmitIntoClient
-     public static func _vjpInit(repeating value: Element) -> (value: Self, pullback: (TangentVector) -> Element.TangentVector) {
-         (
-             value: Self(repeating: value),
-             pullback: { v in
-                 var result: Element.TangentVector = .zero
-                 for i in v.indices {
-                     result += v[i]
-                 }
-                 return result
-             }
-         )
-     }
-     */
+    #if compiler(>=6.3)
+    // This vjp is gated to 6.3+ as it would crash the compiler before 6.3
+    @derivative(of: init)
+    @_alwaysEmitIntoClient
+    public static func _vjpInit(repeating value: Element) -> (value: Self, pullback: (TangentVector) -> Element.TangentVector) {
+        (
+            value: Self(repeating: value),
+            pullback: { v in
+                var result: Element.TangentVector = .zero
+                for i in v.indices {
+                    result += v[i]
+                }
+                return result
+            }
+        )
+    }
+    #endif
 }
 
 @available(macOS 26, iOS 26, *)

--- a/Tests/DifferentiationTests/InlineArrayTests.swift
+++ b/Tests/DifferentiationTests/InlineArrayTests.swift
@@ -28,29 +28,28 @@ struct InlineArrayTests {
         #expect(diff[1] == 1.5)
     }
 
-    // disabled until Swift 6.3 as we can't register derivative for methods marked @_alwaysEmitIntoClient for now.
-    /*
-     // Test differentiable init(repeating:)
-     @Test("vjp of init(repeating:) aggregates tangent inputs correctly")
-     @available(macOS 26, iOS 26, *)
-     func testVJPInitRepeating() {
-         // For differentiable init(repeating:), the pullback should sum all elements of the tangent vector
-         let repeated = InlineArray<2, Double>(repeating: 4.0)
-         // forward run
-         // Now test pullback: apply VJP
-         // The API for using VJP: call `valueWithPullback` or similar
-         let (value, pullback) = valueWithPullback(at: 4.0, of: { value in InlineArray<2, Double>(repeating: value) })
-         // value should equal what init(repeating:) produces
-         #expect(value == repeated)
+    #if compiler(>=6.3)
+    // Test differentiable init(repeating:)
+    @Test("vjp of init(repeating:) aggregates tangent inputs correctly")
+    @available(macOS 26, iOS 26, *)
+    func testVJPInitRepeating() {
+        // For differentiable init(repeating:), the pullback should sum all elements of the tangent vector
+        let repeated = InlineArray<2, Double>(repeating: 4.0)
+        // forward run
+        // Now test pullback: apply VJP
+        // The API for using VJP: call `valueWithPullback` or similar
+        let (value, pullback) = valueWithPullback(at: 4.0, of: { value in InlineArray<2, Double>(repeating: value) })
+        // value should equal what init(repeating:) produces
+        #expect(value == repeated)
+        // construct some tangent vector
+        let tv: InlineArray<2, Double> = [10.0, 20.0]
+        // apply pullback
+        let back = pullback(tv)
+        // Should equal sum of elements, i.e. 10 + 20 == 30, as Double’s tangent
+        #expect(back == 30.0)
+    }
+    #endif
 
-         // construct some tangent vector
-         let tv: InlineArray<2, Double> = [10.0, 20.0]
-         // apply pullback
-         let back = pullback(tv)
-         // Should equal sum of elements, i.e. 10 + 20 == 30, as Double’s tangent
-         #expect(back == 30.0)
-     }
-      */
     @Test("vjp of subscript.get(ad:) is correct")
     @available(macOS 26, iOS 26, *)
     func testVJPSubscriptGetAD() {


### PR DESCRIPTION
enables a vjp that was previously blocked by a compiler crash